### PR TITLE
Fix install instructions related to Apple M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,16 @@ On Ubuntu, run the following to install Python:
 sudo apt install python3.8 python3.8-venv
 ```
 
-or, if you are running a conda environment, you can get things setup with the following:
+
+If you want to use conda, first install it:
+
+- [Install Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html)
+
+You can get things setup with the following:
 
 ```sh
-conda env create -f scitt-api-emulator.yml
-conda activate scitt
+conda env create -f environment.yml
+conda activate scitt # this command fails for me
 ```
 
 ## Clone the emulator

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can get things setup with the following:
 
 ```sh
 conda env create -f environment.yml
-conda activate scitt # this command fails for me
+conda activate scitt
 ```
 
 ## Clone the emulator

--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - rfc3986=1.5.0
   - setuptools=66.1.1
   - wheel=0.38.4
+  - pip=22.3.1
   - pip:
     - asn1crypto==1.5.1
     - cbor2==5.4.6

--- a/scitt-emulator.sh
+++ b/scitt-emulator.sh
@@ -6,7 +6,7 @@ set -e
 
 if [ ! -f "venv/bin/activate" ]; then
     echo "Setting up Python virtual environment."
-    python3.8 -m venv "venv"
+    python -m venv "venv"
     . ./venv/bin/activate
     pip install -q -e .
 else

--- a/scitt-emulator.sh
+++ b/scitt-emulator.sh
@@ -6,7 +6,7 @@ set -e
 
 if [ ! -f "venv/bin/activate" ]; then
     echo "Setting up Python virtual environment."
-    python -m venv "venv"
+    python3 -m venv "venv"
     . ./venv/bin/activate
     pip install -q -e .
 else


### PR DESCRIPTION
Attempting to resolve: https://github.com/scitt-community/scitt-api-emulator/issues/17


I still get errors even after the corrections made in the branch... I think in may be Apple M1 related...

See this trace:

```
Package colorama conflicts for:
flask=2.2.2 -> click[version='>=8.0'] -> colorama
pytest=7.2.1 -> coloramaThe following specifications were found to be incompatible with your system:

  - feature:/osx-arm64::__unix==0=0
  - feature:|@/osx-arm64::__unix==0=0
  - flask=2.2.2 -> click[version='>=8.0'] -> __unix
  - flask=2.2.2 -> click[version='>=8.0'] -> __win

Your installed version is: 0
```

This command fails, due to environment setup failure on Apple M1.

```
conda activate scitt
```