### PR TITLE
CI/CD for container image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,34 @@ jobs:
         activate-environment: scitt
         environment-file: environment.yml
     - run: python -m pytest
+
+  ci-cd-build-and-push-image-container:
+    name: CI/CD (container)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      CONTAINER_IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.CONTAINER_IMAGE_NAME }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.8
+
+WORKDIR /usr/src/scitt-api-emulater
+
+COPY setup.py ./
+RUN mkdir -p scitt_emulater \
+  && pip install --no-cache-dir -e .
+
+COPY . .
+
+RUN pip install --no-cache-dir -e .
+
+CMD scitt-emulator server --workspace workspace/ --tree-alg CCF

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+# Usage
+#
+# Virtual CCF (non-SGX) build and run:
+#   $ docker build -t ghcr.io/scitt-community/scitt-api-emulator:main --progress plain .
+#   $ docker run --rm -ti -w /src/src/scitt-api-emulator -v $PWD:/src/src/scitt-api-emulator -p 8000:8000 ghcr.io/scitt-community/scitt-api-emulator:main
 FROM python:3.8
 
 WORKDIR /usr/src/scitt-api-emulater


### PR DESCRIPTION
- Add Dockerfile
- Add container build to CI
- References
  - https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
  - https://hub.docker.com/_/python/

```console
$ docker build -t ghcr.io/scitt-community/scitt-api-emulator:main --progress plain .
$ docker run --rm -ti -w /src/src/scitt-api-emulator -v $PWD:/src/src/scitt-api-emulator -p 8000:8000 ghcr.io/scitt-community/scitt-api-emulator:main
```

- Future
  - Enclave (non-virtual CCF) capable containers https://gramine.readthedocs.io/projects/gsc/en/latest/