### PR TITLE
Simple decoupled file based policy engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ The `service_parameters.json` file gets created when starting a service using `.
     "serviceId": "emulator",
     "treeAlgorithm": "CCF",
     "signatureAlgorithm": "ES256",
+    "insertPolicy": "*",
     "serviceCertificate": "-----BEGIN CERTIFICATE-----..."
 }
 ```

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ pytest
 requests==2.31.0
 requests-toolbelt==0.9
 urllib3<2.0.0
+myst-parser

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 pyOpenSSL
 pytest
+jsonschema
 requests==2.31.0
 requests-toolbelt==0.9
 urllib3<2.0.0

--- a/docs/registration_policies.md
+++ b/docs/registration_policies.md
@@ -1,0 +1,124 @@
+# Registration Policies
+
+- References
+  - [5.2.2. Registration Policies](https://www.ietf.org/archive/id/draft-birkholz-scitt-architecture-02.html#name-registration-policies)
+
+## Simple decoupled file based policy engine
+
+The SCITT API emulator can deny entry based on presence of
+`operation.policy.{insert,denied,failed}` files. Currently only for use with
+`use_lro=True`.
+
+This is a simple way to enable evaluation of claims prior to submission by
+arbitrary policy engines which watch the workspace (fanotify, inotify, etc.).
+
+Start the server
+
+```console
+$ rm -rf workspace/
+$ mkdir -p workspace/storage/operations
+$ scitt-emulator server --workspace workspace/ --tree-alg CCF --use-lro
+Service parameters: workspace/service_parameters.json
+^C
+```
+
+Modification of config to non-`*` insert policy. Restart SCITT API emulator server after this.
+
+```console
+$ echo "$(cat workspace/service_parameters.json)" \
+    | jq '.insertPolicy = "external"' \
+    | tee workspace/service_parameters.json.new \
+    && mv workspace/service_parameters.json.new workspace/service_parameters.json
+{
+  "serviceId": "emulator",
+  "treeAlgorithm": "CCF",
+  "signatureAlgorithm": "ES256",
+  "serviceCertificate": "-----BEGIN CERTIFICATE-----",
+  "insertPolicy": "external"
+}
+```
+
+Basic policy engine in two files
+
+**enforce_policy.py**
+
+```python
+import os
+import sys
+import pathlib
+
+cose_path = pathlib.Path(sys.argv[-1])
+policy_action_path = cose_path.with_suffix(".policy." + os.environ["POLICY_ACTION"].lower())
+policy_action_path.write_text("")
+```
+
+Simple drop rule based on claim content blocklist.
+
+**is_on_blocklist.py**
+
+```python
+import os
+import sys
+import json
+
+import cbor2
+import pycose
+from pycose.messages import CoseMessage, Sign1Message
+
+from scitt_emulator.scitt import ClaimInvalidError, COSE_Headers_Issuer
+
+BLOCKLIST_DEFAULT = [
+    "did:web:example.com",
+]
+BLOCKLIST_DEFAULT_JSON = json.dumps(BLOCKLIST_DEFAULT)
+BLOCKLIST = json.loads(os.environ.get("BLOCKLIST", BLOCKLIST_DEFAULT_JSON))
+
+claim = sys.stdin.buffer.read()
+
+msg = CoseMessage.decode(claim)
+
+if pycose.headers.ContentType not in msg.phdr:
+    raise ClaimInvalidError(
+        "Claim does not have a content type header parameter"
+    )
+if COSE_Headers_Issuer not in msg.phdr:
+    raise ClaimInvalidError("Claim does not have an issuer header parameter")
+
+if msg.phdr[COSE_Headers_Issuer] not in BLOCKLIST:
+    sys.exit(1)
+
+# EXIT_SUCCESS == MUST block. In case of thrown errors/exceptions.
+```
+
+Example running blocklist check and enforcement to disable issuer (example:
+`did:web:example.com`).
+
+```console
+$ npm install -g nodemon
+$ nodemon -e .cose --exec 'find workspace/storage/operations -name \*.cose -exec nohup sh -xc "echo {} && (python3 is_on_blocklist.py < {} && POLICY_ACTION=denied python3 enforce_policy.py {}) || POLICY_ACTION=insert python3 enforce_policy.py {}" \;'
+```
+
+Create claim from blocked issuer (`.com`) and from non-blocked (`.org`).
+
+```console
+$ scitt-emulator client create-claim --issuer did:web:example.com --content-type application/json --payload '{"sun": "yellow"}' --out claim.cose
+Claim written to claim.cose
+$ scitt-emulator client submit-claim --claim claim.cose --out claim.receipt.cbor
+Traceback (most recent call last):
+  File "/home/alice/.local/bin/scitt-emulator", line 33, in <module>
+    sys.exit(load_entry_point('scitt-emulator', 'console_scripts', 'scitt-emulator')())
+  File "/home/alice/Documents/python/scitt-api-emulator/scitt_emulator/cli.py", line 22, in main
+    args.func(args)
+  File "/home/alice/Documents/python/scitt-api-emulator/scitt_emulator/client.py", line 182, in <lambda>
+    func=lambda args: submit_claim(
+  File "/home/alice/Documents/python/scitt-api-emulator/scitt_emulator/client.py", line 93, in submit_claim
+    raise_for_operation_status(operation)
+  File "/home/alice/Documents/python/scitt-api-emulator/scitt_emulator/client.py", line 29, in raise_for_operation_status
+    raise RuntimeError(f"Operation error: {operation['error']}")
+RuntimeError: Operation error: {'status': 'denied'}
+$ scitt-emulator client create-claim --issuer did:web:example.org --content-type application/json --payload '{"sun": "yellow"}' --out claim.cose
+Claim written to claim.cose
+$ scitt-emulator client submit-claim --claim claim.cose --out claim.receipt.cbor
+Claim registered with entry ID 1
+Receipt written to claim.receipt.cbor
+```

--- a/docs/registration_policies.md
+++ b/docs/registration_policies.md
@@ -100,7 +100,7 @@ validate(
     instance={
         "$schema": "TODO",
         "issuer": msg.phdr[COSE_Headers_Issuer],
-        "cliam": json.loads(msg.payload),
+        "cliam": json.loads(msg.payload.decode()),
     },
     schema=SCHEMA,
 )

--- a/docs/registration_policies.md
+++ b/docs/registration_policies.md
@@ -28,7 +28,7 @@ Modification of config to non-`*` insert policy. Restart SCITT API emulator serv
 
 ```console
 $ echo "$(cat workspace/service_parameters.json)" \
-    | jq '.insertPolicy = "external"' \
+    | jq '.insertPolicy = "blocklist.schema.json"' \
     | tee workspace/service_parameters.json.new \
     && mv workspace/service_parameters.json.new workspace/service_parameters.json
 {
@@ -36,7 +36,7 @@ $ echo "$(cat workspace/service_parameters.json)" \
   "treeAlgorithm": "CCF",
   "signatureAlgorithm": "ES256",
   "serviceCertificate": "-----BEGIN CERTIFICATE-----",
-  "insertPolicy": "external"
+  "insertPolicy": "blocklist.schema.json"
 }
 ```
 
@@ -60,25 +60,49 @@ policy_action_path.write_text(policy_reason)
 
 Simple drop rule based on claim content blocklist.
 
-**is_on_blocklist.py**
+**blocklist.schema.json**
+
+```json
+{
+    "$id": "https://schema.example.com/scitt-blocklist.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "$schema": {
+            "type": "string"
+        },
+        "@context": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "issuer": {
+            "type": "string",
+            "not": {
+                "enum": [
+                    "did:web:example.com"
+                ]
+            }
+        }
+    }
+}
+```
+
+**jsonschema_validator.py**
 
 ```python
 import os
 import sys
 import json
+import pathlib
+import traceback
 
 import cbor2
 import pycose
-from jsonschema import validate
+from jsonschema import validate, ValidationError
 from pycose.messages import CoseMessage, Sign1Message
 
 from scitt_emulator.scitt import ClaimInvalidError, COSE_Headers_Issuer
-
-BLOCKLIST_DEFAULT = [
-    "did:web:example.com",
-]
-BLOCKLIST_DEFAULT_JSON = json.dumps(BLOCKLIST_DEFAULT)
-BLOCKLIST = json.loads(os.environ.get("BLOCKLIST", BLOCKLIST_DEFAULT_JSON))
 
 claim = sys.stdin.buffer.read()
 
@@ -89,21 +113,39 @@ if pycose.headers.ContentType not in msg.phdr:
 if COSE_Headers_Issuer not in msg.phdr:
     raise ClaimInvalidError("Claim does not have an issuer header parameter")
 
-if not msg[pycose.headers.ContentType].startswith("application/json"):
+if not msg.phdr[pycose.headers.ContentType].startswith("application/json"):
     raise TypeError(
-        f"Claim content type does not start with application/json: {msg[pycose.headers.ContentType]!r}"
+        f"Claim content type does not start with application/json: {msg.phdr[pycose.headers.ContentType]!r}"
     )
 
-SCHEMA = json.loads(pathlib.Path(os.environ["SCHEMA"]).read_text())
+SCHEMA = json.loads(pathlib.Path(os.environ["SCHEMA_PATH"]).read_text())
 
-validate(
-    instance={
-        "$schema": "TODO",
-        "issuer": msg.phdr[COSE_Headers_Issuer],
-        "cliam": json.loads(msg.payload.decode()),
-    },
-    schema=SCHEMA,
-)
+try:
+    validate(
+        instance={
+            "$schema": "TODO",
+            "issuer": msg.phdr[COSE_Headers_Issuer],
+            "claim": json.loads(msg.payload.decode()),
+        },
+        schema=SCHEMA,
+    )
+except ValidationError as error:
+    print(str(error), file=sys.stderr)
+    sys.exit(1)
+```
+
+We'll create a small wrapper to serve in place of a more fully featured policy
+engine.
+
+**policy_engine.sh**
+
+```bash
+export SCHEMA_PATH="${1}"
+CLAIM_PATH="${2}"
+
+echo ${CLAIM_PATH}
+
+(python3 jsonschema_validator.py < ${CLAIM_PATH} 2>error && POLICY_ACTION=insert python3 enforce_policy.py ${CLAIM_PATH}) || (python3 -c 'import sys, json; print(json.dumps({"type": "denied", "detail": json.dumps(sys.stdin.read())}))' < error > reason.json; POLICY_ACTION=denied POLICY_REASON_PATH=reason.json python3 enforce_policy.py ${CLAIM_PATH})
 ```
 
 Example running blocklist check and enforcement to disable issuer (example:
@@ -111,8 +153,13 @@ Example running blocklist check and enforcement to disable issuer (example:
 
 ```console
 $ npm install -g nodemon
-$ echo '{"type": "denied", "detail": "content_address_of_reason"}' | tee reason.json
-$ nodemon -e .cose --exec 'find workspace/storage/operations -name \*.cose -exec nohup sh -xc "echo {} && (python3 is_on_blocklist.py < {} && POLICY_ACTION=denied POLICY_REASON_PATH=reason.json python3 enforce_policy.py {}) || POLICY_ACTION=insert python3 enforce_policy.py {}" \;'
+$ nodemon -e .cose --exec 'find workspace/storage/operations -name \*.cose -exec nohup sh -xe policy_engine.sh $(cat workspace/service_parameters.json | jq -r .insertPolicy) {} \;'
+```
+
+Also ensure you restart the server with the new config we edited.
+
+```console
+$ scitt-emulator server --workspace workspace/ --tree-alg CCF --use-lro
 ```
 
 Create claim from blocked issuer (`.com`) and from non-blocked (`.org`).
@@ -132,7 +179,7 @@ Traceback (most recent call last):
     raise_for_operation_status(operation)
   File "/home/alice/Documents/python/scitt-api-emulator/scitt_emulator/client.py", line 37, in raise_for_operation_status
     raise ClaimOperationError(operation)
-scitt_emulator.client.ClaimOperationError: Operation error: {'error': {'detail': 'content_address_of_reason', 'type': 'denied'}, 'operationId': '9693b076-f992-44e1-b7b9-865c600a96f7', 'status': 'failed'}
+scitt_emulator.client.ClaimOperationError: Operation error: {'error': {'detail': '"\'did:web:example.com\' should not be valid under {\'enum\': [\'did:web:example.com\']}\\n\\nFailed validating \'not\' in schema[\'properties\'][\'issuer\']:\\n    {\'not\': {\'enum\': [\'did:web:example.com\']}, \'type\': \'string\'}\\n\\nOn instance[\'issuer\']:\\n    \'did:web:example.com\'\\n"', 'type': 'denied'}, 'operationId': '7bf1101b-ec10-409f-884a-a3747a270394', 'status': 'failed'}
 $ scitt-emulator client create-claim --issuer did:web:example.org --content-type application/json --payload '{"sun": "yellow"}' --out claim.cose
 Claim written to claim.cose
 $ scitt-emulator client submit-claim --claim claim.cose --out claim.receipt.cbor

--- a/docs/registration_policies.md
+++ b/docs/registration_policies.md
@@ -134,7 +134,7 @@ CLAIM_PATH="${2}"
 
 echo ${CLAIM_PATH}
 
-(python3 jsonschema_validator.py < ${CLAIM_PATH} 2>error && POLICY_ACTION=insert python3 enforce_policy.py ${CLAIM_PATH}) || (python3 -c 'import sys, json; print(json.dumps({"type": "denied", "detail": json.dumps(sys.stdin.read())}))' < error > reason.json; POLICY_ACTION=denied POLICY_REASON_PATH=reason.json python3 enforce_policy.py ${CLAIM_PATH})
+(python3 jsonschema_validator.py < ${CLAIM_PATH} 2>error && POLICY_ACTION=insert python3 enforce_policy.py ${CLAIM_PATH}) || (python3 -c 'import sys, json; print(json.dumps({"type": "denied", "detail": sys.stdin.read()}))' < error > reason.json; POLICY_ACTION=denied POLICY_REASON_PATH=reason.json python3 enforce_policy.py ${CLAIM_PATH})
 ```
 
 Example running allowlist check and enforcement.
@@ -161,13 +161,20 @@ Traceback (most recent call last):
     sys.exit(load_entry_point('scitt-emulator', 'console_scripts', 'scitt-emulator')())
   File "/home/alice/Documents/python/scitt-api-emulator/scitt_emulator/cli.py", line 22, in main
     args.func(args)
-  File "/home/alice/Documents/python/scitt-api-emulator/scitt_emulator/client.py", line 190, in <lambda>
+  File "/home/alice/Documents/python/scitt-api-emulator/scitt_emulator/client.py", line 196, in <lambda>
     func=lambda args: submit_claim(
-  File "/home/alice/Documents/python/scitt-api-emulator/scitt_emulator/client.py", line 101, in submit_claim
+  File "/home/alice/Documents/python/scitt-api-emulator/scitt_emulator/client.py", line 107, in submit_claim
     raise_for_operation_status(operation)
-  File "/home/alice/Documents/python/scitt-api-emulator/scitt_emulator/client.py", line 37, in raise_for_operation_status
+  File "/home/alice/Documents/python/scitt-api-emulator/scitt_emulator/client.py", line 43, in raise_for_operation_status
     raise ClaimOperationError(operation)
-scitt_emulator.client.ClaimOperationError: Operation error: {'error': {'detail': '"\'did:web:example.com\' should not be valid under {\'enum\': [\'did:web:example.com\']}\\n\\nFailed validating \'not\' in schema[\'properties\'][\'issuer\']:\\n    {\'not\': {\'enum\': [\'did:web:example.com\']}, \'type\': \'string\'}\\n\\nOn instance[\'issuer\']:\\n    \'did:web:example.com\'\\n"', 'type': 'denied'}, 'operationId': '7bf1101b-ec10-409f-884a-a3747a270394', 'status': 'failed'}
+scitt_emulator.client.ClaimOperationError: Operation error denied: 'did:web:example.com' is not one of ['did:web:example.org']
+
+Failed validating 'enum' in schema['properties']['issuer']:
+    {'enum': ['did:web:example.org'], 'type': 'string'}
+
+On instance['issuer']:
+    'did:web:example.com'
+
 $ scitt-emulator client create-claim --issuer did:web:example.org --content-type application/json --payload '{"sun": "yellow"}' --out claim.cose
 Claim written to claim.cose
 $ scitt-emulator client submit-claim --claim claim.cose --out claim.receipt.cbor

--- a/docs/registration_policies.md
+++ b/docs/registration_policies.md
@@ -12,6 +12,8 @@ The SCITT API emulator can deny entry based on presence of
 This is a simple way to enable evaluation of claims prior to submission by
 arbitrary policy engines which watch the workspace (fanotify, inotify, etc.).
 
+[![asciicast-of-simple-decoupled-file-based-policy-engine](https://asciinema.org/a/572766.svg)](https://asciinema.org/a/572766)
+
 Start the server
 
 ```console

--- a/environment.yml
+++ b/environment.yml
@@ -34,3 +34,4 @@ dependencies:
     - rkvst-archivist==0.20.0
     - six==1.16.0
     - urllib3<2.0.0
+    - myst-parser==1.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -35,3 +35,4 @@ dependencies:
     - six==1.16.0
     - urllib3<2.0.0
     - myst-parser==1.0.0
+    - jsonschema==4.17.3

--- a/scitt_emulator/client.py
+++ b/scitt_emulator/client.py
@@ -22,7 +22,13 @@ class ClaimOperationError(Exception):
         self.operation = operation
 
     def __str__(self):
-        return f"Operation error: {self.operation}"
+        error_type = self.operation.get("error", {}).get(
+            "type", "error.type not present",
+        )
+        error_detail = self.operation.get("error", {}).get(
+            "detail", "error.detail not present",
+        )
+        return f"Operation error {error_type}: {error_detail}"
 
 
 def raise_for_status(response: httpx.Response):

--- a/scitt_emulator/client.py
+++ b/scitt_emulator/client.py
@@ -17,6 +17,14 @@ HTTP_RETRIES = 3
 HTTP_DEFAULT_RETRY_DELAY = 1
 
 
+class ClaimOperationError(Exception):
+    def __init__(self, operation):
+        self.operation = operation
+
+    def __str__(self):
+        return f"Operation error: {self.operation}"
+
+
 def raise_for_status(response: httpx.Response):
     if response.is_success:
         return
@@ -26,7 +34,7 @@ def raise_for_status(response: httpx.Response):
 def raise_for_operation_status(operation: dict):
     if operation["status"] != "failed":
         return
-    raise RuntimeError(f"Operation error: {operation['error']}")
+    raise ClaimOperationError(operation)
 
 
 class HttpClient:

--- a/scitt_emulator/scitt.py
+++ b/scitt_emulator/scitt.py
@@ -22,6 +22,10 @@ COSE_Headers_Service_Id = "service_id"
 COSE_Headers_Tree_Alg = "tree_alg"
 COSE_Headers_Issued_At = "issued_at"
 
+# permissive insert policy
+MOST_PERMISSIVE_INSERT_POLICY = "*"
+DEFAULT_INSERT_POLICY = MOST_PERMISSIVE_INSERT_POLICY
+
 
 class ClaimInvalidError(Exception):
     pass
@@ -94,8 +98,14 @@ class SCITTServiceEmulator(ABC):
         return claim
 
     def submit_claim(self, claim: bytes, long_running=True) -> dict:
+        insert_policy = self.service_parameters.get("insertPolicy", DEFAULT_INSERT_POLICY)
+
         if long_running:
             return self._create_operation(claim)
+        elif insert_policy != MOST_PERMISSIVE_INSERT_POLICY:
+            raise NotImplementedError(
+                f"non-* insertPolicy only works with long_running=True: {insert_policy!r}"
+            )
         else:
             return self._create_entry(claim)
 
@@ -142,10 +152,43 @@ class SCITTServiceEmulator(ABC):
 
         return operation
 
+    def _sync_policy_result(self, operation: dict):
+        operation_id = operation["operationId"]
+        policy_insert_path = self.operations_path / f"{operation_id}.policy.insert"
+        policy_denied_path = self.operations_path / f"{operation_id}.policy.denied"
+        policy_failed_path = self.operations_path / f"{operation_id}.policy.failed"
+        insert_policy = self.service_parameters.get("insertPolicy", DEFAULT_INSERT_POLICY)
+
+        policy_result = {"status": operation["status"]}
+
+        if insert_policy == MOST_PERMISSIVE_INSERT_POLICY:
+            policy_result["status"] = "succeeded"
+        if policy_insert_path.exists():
+            policy_result["status"] = "succeeded"
+            policy_insert_path.unlink()
+        if policy_failed_path.exists():
+            policy_result["status"] = "failed"
+            policy_failed_path.unlink()
+        if policy_denied_path.exists():
+            policy_result["status"] = "denied"
+            policy_denied_path.unlink()
+
+        return policy_result
+
     def _finish_operation(self, operation: dict):
         operation_id = operation["operationId"]
         operation_path = self.operations_path / f"{operation_id}.json"
         claim_src_path = self.operations_path / f"{operation_id}.cose"
+
+        policy_result = self._sync_policy_result(operation)
+        if policy_result["status"] == "running":
+            return operation
+        if policy_result["status"] != "succeeded":
+            operation["status"] = "failed"
+            operation["error"] = policy_result
+            operation_path.unlink()
+            claim_src_path.unlink()
+            return operation
 
         claim = claim_src_path.read_bytes()
         entry = self._create_entry(claim)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,214 @@
+# Copyright (c) SCITT Authors
+# Licensed under the MIT License.
+import os
+import sys
+import time
+import types
+import pathlib
+import threading
+import itertools
+import subprocess
+import contextlib
+import unittest.mock
+import pytest
+import myst_parser.parsers.docutils_
+import docutils.nodes
+import docutils.utils
+
+from .test_cli import (
+    Service,
+    content_type,
+    payload,
+    execute_cli,
+)
+
+
+repo_root = pathlib.Path(__file__).parents[1]
+docs_dir = repo_root.joinpath("docs")
+blocklisted_issuer = "did:web:example.com"
+non_blocklisted_issuer = "did:web:example.org"
+
+
+class SimpleFileBasedPolicyEngine:
+    def __init__(self, config):
+        self.config = config
+
+    def __enter__(self):
+        self.stop_event = threading.Event()
+        self.thread = threading.Thread(
+            name="policy",
+            target=self.poll_workspace,
+            args=[self.config, self.stop_event],
+        )
+        self.thread.start()
+        return self
+
+    def __exit__(self, *args):
+        self.stop_event.set()
+        self.thread.join()
+
+    @staticmethod
+    def poll_workspace(config, stop_event):
+        operations_path = pathlib.Path(config["storage_path"], "operations")
+        command_is_on_blocklist = [
+            sys.executable,
+            str(config["is_on_blocklist"].resolve()),
+        ]
+        command_enforce_policy = [
+            sys.executable,
+            str(config["enforce_policy"].resolve()),
+        ]
+
+        running = True
+        while running:
+            for cose_path in operations_path.glob("*.cose"):
+                with open(cose_path, "rb") as stdin_fileobj:
+                    exit_code = subprocess.call(
+                        command_is_on_blocklist,
+                        stdin=stdin_fileobj,
+                    )
+                # EXIT_SUCCESS from blocklist == MUST block
+                env = {
+                    **os.environ,
+                    "POLICY_ACTION": {
+                        0: "denied",
+                    }.get(exit_code, "insert"),
+                }
+                command = command_enforce_policy + [cose_path]
+                exit_code = subprocess.call(command, env=env)
+            time.sleep(0.1)
+            running = not stop_event.is_set()
+
+def docutils_recursively_extract_nodes(node, samples = None):
+    if samples is None:
+        samples = []
+    if isinstance(node, list):
+        node = types.SimpleNamespace(children=node)
+    return samples + list(itertools.chain(*[
+        [
+            child,
+            *docutils_recursively_extract_nodes(child),
+        ]
+        for child in node.children
+        if hasattr(child, "children")
+    ]))
+
+def docutils_find_code_samples(nodes):
+    samples = {}
+    for i, node in enumerate(nodes):
+        # Look ahead for next literal block with code sample. Pattern is:
+        #
+        # **strong.suffix**
+        #
+        # ```language
+        # content
+        # ````
+        # TODO Gracefully handle expections to index out of bounds
+        if (
+            isinstance(node, docutils.nodes.strong)
+            and isinstance(nodes[i + 3], docutils.nodes.literal_block)
+        ):
+            samples[node.astext()] = nodes[i + 3].astext()
+    return samples
+
+def test_docs_registration_policies(tmp_path):
+    workspace_path = tmp_path / "workspace"
+
+    claim_path = tmp_path / "claim.cose"
+    receipt_path = tmp_path / "claim.receipt.cbor"
+    entry_id_path = tmp_path / "claim.entry_id.txt"
+    retrieved_claim_path = tmp_path / "claim.retrieved.cose"
+
+    # Grab code samples from docs
+    # TODO Abstract into abitrary docs testing code
+    doc_path = docs_dir.joinpath("registration_policies.md")
+    markdown_parser = myst_parser.parsers.docutils_.Parser()
+    document = docutils.utils.new_document(str(doc_path.resolve()))
+    parsed = markdown_parser.parse(doc_path.read_text(), document)
+    nodes = docutils_recursively_extract_nodes(document)
+    for name, content in docutils_find_code_samples(nodes).items():
+        tmp_path.joinpath(name).write_text(content)
+
+    with Service(
+        {
+            "tree_alg": "CCF",
+            "workspace": workspace_path,
+            "error_rate": 0.1,
+            "use_lro": True,
+        }
+    ) as service, SimpleFileBasedPolicyEngine(
+        {
+            "storage_path": service.server.app.scitt_service.storage_path,
+            "enforce_policy": tmp_path.joinpath("enforce_policy.py"),
+            "is_on_blocklist": tmp_path.joinpath("is_on_blocklist.py"),
+        }
+    ) as policy_engine:
+        # set the policy to enforce
+        service.server.app.scitt_service.service_parameters["insertPolicy"] = "external"
+
+        # create denied claim
+        command = [
+            "client",
+            "create-claim",
+            "--out",
+            claim_path,
+            "--issuer",
+            blocklisted_issuer,
+            "--content-type",
+            content_type,
+            "--payload",
+            payload,
+        ]
+        execute_cli(command)
+        assert os.path.exists(claim_path)
+
+        # submit denied claim
+        command = [
+            "client",
+            "submit-claim",
+            "--claim",
+            claim_path,
+            "--out",
+            receipt_path,
+            "--out-entry-id",
+            entry_id_path,
+            "--url",
+            service.url
+        ]
+        with pytest.raises(RuntimeError, match=r"denied"):
+            execute_cli(command)
+        assert not os.path.exists(receipt_path)
+        assert not os.path.exists(entry_id_path)
+
+        # create accepted claim
+        command = [
+            "client",
+            "create-claim",
+            "--out",
+            claim_path,
+            "--issuer",
+            non_blocklisted_issuer,
+            "--content-type",
+            content_type,
+            "--payload",
+            payload,
+        ]
+        execute_cli(command)
+        assert os.path.exists(claim_path)
+
+        # submit accepted claim
+        command = [
+            "client",
+            "submit-claim",
+            "--claim",
+            claim_path,
+            "--out",
+            receipt_path,
+            "--out-entry-id",
+            entry_id_path,
+            "--url",
+            service.url
+        ]
+        execute_cli(command)
+        assert os.path.exists(receipt_path)
+        assert os.path.exists(entry_id_path)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -88,6 +88,10 @@ class SimpleFileBasedPolicyEngine:
                     env = {
                         **os.environ,
                         "SCHEMA_PATH": str(config["schema_path"].resolve()),
+                        "PYTHONPATH": ":".join(
+                            os.environ.get("PYTHONPATH", "").split(":")
+                            + [str(pathlib.Path(__file__).parents[1].resolve())]
+                        ),
                     }
                     exit_code = 0
                     try:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -31,17 +31,17 @@ from .test_cli import (
 
 repo_root = pathlib.Path(__file__).parents[1]
 docs_dir = repo_root.joinpath("docs")
-blocklisted_issuer = "did:web:example.com"
-non_blocklisted_issuer = "did:web:example.org"
+allowlisted_issuer = "did:web:example.org"
+non_allowlisted_issuer = "did:web:example.com"
 CLAIM_DENIED_ERROR = {"type": "denied", "detail": "content_address_of_reason"}
 CLAIM_DENIED_ERROR_BLOCKED = {
     "type": "denied",
     "detail": textwrap.dedent(
         """
-        'did:web:example.com' should not be valid under {'enum': ['did:web:example.com']}
+        'did:web:example.com' is not one of ['did:web:example.org']
 
-        Failed validating 'not' in schema['properties']['issuer']:
-            {'not': {'enum': ['did:web:example.com']}, 'type': 'string'}
+        Failed validating 'enum' in schema['properties']['issuer']:
+            {'enum': ['did:web:example.org'], 'type': 'string'}
 
         On instance['issuer']:
             'did:web:example.com'
@@ -133,7 +133,7 @@ def docutils_recursively_extract_nodes(node, samples = None):
 def docutils_find_code_samples(nodes):
     samples = {}
     for i, node in enumerate(nodes):
-        # Look ahead for next literal block with code sample. Pattern is:
+        # Look ahead for next literal allow with code sample. Pattern is:
         #
         # **strong.suffix**
         #
@@ -178,7 +178,7 @@ def test_docs_registration_policies(tmp_path):
             "storage_path": service.server.app.scitt_service.storage_path,
             "enforce_policy": tmp_path.joinpath("enforce_policy.py"),
             "jsonschema_validator": tmp_path.joinpath("jsonschema_validator.py"),
-            "schema_path": tmp_path.joinpath("blocklist.schema.json"),
+            "schema_path": tmp_path.joinpath("allowlist.schema.json"),
         }
     ) as policy_engine:
         # set the policy to enforce
@@ -191,7 +191,7 @@ def test_docs_registration_policies(tmp_path):
             "--out",
             claim_path,
             "--issuer",
-            blocklisted_issuer,
+            non_allowlisted_issuer,
             "--content-type",
             content_type,
             "--payload",
@@ -231,7 +231,7 @@ def test_docs_registration_policies(tmp_path):
             "--out",
             claim_path,
             "--issuer",
-            non_blocklisted_issuer,
+            allowlisted_issuer,
             "--content-type",
             content_type,
             "--payload",


### PR DESCRIPTION
Simple insert policy based engine based on presence of `operation.policy.{insert,denied,failed}` files. Currently only for use with `use_lro=True`. This is a simple way to enable evaluation of claims prior to submission by arbitrary policy engines which watch the workspace (fanotify,  inotify, etc.).

### [Jump to viewing docs](https://github.com/scitt-community/scitt-api-emulator/pull/27/files?short_path=902592d#diff-902592dae6c982dcbc114dc4619188a03c4f5c5f27246b60aca5a1e1c655e1b6)

- References
  - [Associated mailing list thread](https://mailarchive.ietf.org/arch/msg/scitt/PwcesOR1txbHOIjMhMOt01YWDjo/)
  - https://github.com/ietf-scitt/use-cases/pull/18
    - > Recent discussion has revealed most of this use case will be focused on the policy / gatekeeper component and federation components of SCITT.
- TODO
  - [x] Unittests
  - [x] Docs
    - [x] [asciicast](https://github.com/asciinema)
  - [x] failure -> failed typos
  - [x] error.detail
    - Would be great if `detail` was optionally an object. A string is of limited usefulness, the same issue was had with the SPDX 2.X series with regards to description fields.
      - https://github.com/ietf-wg-scitt/draft-ietf-scitt-architecture/pull/60#discussion_r1148486103
      - https://github.com/ietf-wg-scitt/draft-ietf-scitt-architecture/issues/62
    - https://mailarchive.ietf.org/arch/msg/scitt/c0t5zLUJtCQ9_Jrf7mykWXSIn94/
      - Future
        - Updating `operationId` to `operationUrl` is out of scope of this pull request.
- Future
  - Workflow based policy execution within documentation rather than simple bash example