### PR TITLE
OIDC auth middleware with GitHub Actions example workflow

### DIFF
--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -66,11 +66,54 @@ jobs:
       - name: Submit claim
         env:
           OIDC_TOKEN: '${{ steps.github-oidc.outputs.token }}'
+          WORKFLOW_REF: '${{ github.workflow_ref }}'
+          # Use of job_workflow_sha blocked by
+          # https://github.com/actions/runner/issues/2417#issuecomment-1718369460
+          JOB_WORKFLOW_SHA: '${{ github.sha }}'
+          REPOSITORY_OWNER_ID: '${{ github.repository_owner_id }}'
+          REPOSITORY_ID: '${{ github.repository_id }}'
         run: |
           # Create the middleware config file
-          cat > oidc-middleware-config.json <<EOF
+          tee oidc-middleware-config.json <<EOF
           {
               "issuers": ["https://token.actions.githubusercontent.com"],
+              "claim_schema": {
+                  "https://token.actions.githubusercontent.com": {
+                        "\$schema": "https://json-schema.org/draft/2020-12/schema",
+                        "required": [
+                            "job_workflow_ref",
+                            "job_workflow_sha",
+                            "repository_owner_id",
+                            "repository_id"
+                        ],
+                        "properties": {
+                            "job_workflow_ref": {
+                                "type": "string",
+                                "enum": [
+                                    "${WORKFLOW_REF}"
+                                ]
+                            },
+                            "job_workflow_sha": {
+                                "type": "string",
+                                "enum": [
+                                    "${JOB_WORKFLOW_SHA}"
+                                ]
+                            },
+                            "repository_owner_id": {
+                                "type": "string",
+                                "enum": [
+                                    "${REPOSITORY_OWNER_ID}"
+                                ]
+                            },
+                            "repository_id": {
+                                "type": "string",
+                                "enum": [
+                                    "${REPOSITORY_ID}"
+                                ]
+                            }
+                        }
+                    }
+              },
               "audience": "${SCITT_URL}"
           }
           EOF
@@ -79,6 +122,7 @@ jobs:
             scitt-emulator server --port 8080 --workspace workspace/ --tree-alg CCF \
               --middleware scitt_emulator.oidc:OIDCAuthMiddleware \
               --middleware-config-path oidc-middleware-config.json &
+            sleep 1s
           fi
           # Submit the claim using OIDC token as auth
           scitt-emulator client submit-claim --token "${OIDC_TOKEN}" --url "${SCITT_URL}" --claim claim.cose --out claim.receipt.cbor

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -1,0 +1,84 @@
+name: "SCITT Notary"
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
+    inputs:
+      scitt-url:
+        description: 'URL of SCITT instance'
+        type: string
+      payload:
+        description: 'Payload for claim'
+        default: ''
+        type: string
+  workflow_call:
+    inputs:
+      scitt-url:
+        description: 'URL of SCITT instance'
+        type: string
+      payload:
+        description: 'Payload for claim'
+        type: string
+
+jobs:
+  notarize:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      SCITT_URL: '${{ inputs.scitt-url || github.event.inputs.scitt-url }}'
+      PAYLOAD: '${{ inputs.payload || github.event.inputs.payload }}'
+    steps:
+      - name: Set defaults if env vars not set (as happens with on.push trigger)
+        run: |
+          if [[ "x${SCITT_URL}" = "x" ]]; then
+            echo "SCITT_URL=http://localhost:8080" >> "${GITHUB_ENV}"
+          fi
+          if [[ "x${PAYLOAD}" = "x" ]]; then
+            echo 'PAYLOAD={"key": "value"}' >> "${GITHUB_ENV}"
+          fi
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Install SCITT API Emulator
+        run: |
+          pip install -U pip setuptools wheel
+          pip install .[oidc]
+      - name: Install github-script dependencies
+        run: |
+          npm install @actions/core
+      - name: Get OIDC token to use as bearer token for auth to SCITT
+        uses: actions/github-script@v6
+        id: github-oidc
+        with:
+          script: |
+            const {SCITT_URL} = process.env;
+            core.setOutput('token', await core.getIDToken(SCITT_URL));
+      - name: Create claim
+        run: |
+          scitt-emulator client create-claim --issuer did:web:example.org --content-type application/json --payload "${PAYLOAD}" --out claim.cose
+      - name: Submit claim
+        env:
+          OIDC_TOKEN: '${{ steps.github-oidc.outputs.token }}'
+        run: |
+          # Create the middleware config file
+          cat > oidc-middleware-config.json <<EOF
+          {
+              "issuers": ["https://token.actions.githubusercontent.com"],
+              "audience": "${SCITT_URL}"
+          }
+          EOF
+          # Start SCITT using the `OIDCAuthMiddleware` and associated config.
+          if [[ "x${SCITT_URL}" = "xhttp://localhost:8080" ]]; then
+            scitt-emulator server --port 8080 --workspace workspace/ --tree-alg CCF \
+              --middleware scitt_emulator.oidc:OIDCAuthMiddleware \
+              --middleware-config-path oidc-middleware-config.json &
+          fi
+          # Submit the claim using OIDC token as auth
+          scitt-emulator client submit-claim --token "${OIDC_TOKEN}" --url "${SCITT_URL}" --claim claim.cose --out claim.receipt.cbor

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,5 @@ requests==2.31.0
 requests-toolbelt==0.9
 urllib3<2.0.0
 myst-parser
+PyJWT
+jwcrypto

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -1,0 +1,23 @@
+# OIDC Support
+
+- References
+  - [5.1.1.1.1.](https://github.com/ietf-wg-scitt/draft-ietf-scitt-architecture/blob/main/draft-ietf-scitt-architecture.md#comment-on-oidc)
+
+[![asciicast-of-oidc-auth-issued-by-github-actions](https://asciinema.org/a/607600.svg)](https://asciinema.org/a/607600)
+
+## Dependencies
+
+Install the SCITT API Emulator with the `oidc` extra.
+
+```console
+$ pip install -e .[oidc]
+```
+
+## Usage example with GitHub Actions
+
+See [`notarize.yml`](../.github/workflows/notarize.yml)
+
+References:
+
+- https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/using-openid-connect-with-reusable-workflows
+- https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect

--- a/environment.yml
+++ b/environment.yml
@@ -36,3 +36,5 @@ dependencies:
     - urllib3<2.0.0
     - myst-parser==1.0.0
     - jsonschema==4.17.3
+    - jwcrypto==1.5.0
+    - PyJWT==2.8.0

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -8,8 +8,9 @@ if [ ! -f "venv/bin/activate" ]; then
     echo "Setting up Python virtual environment."
     python3 -m venv "venv"
     . ./venv/bin/activate
+    pip install -q -U pip setuptools wheel
     pip install -q -r dev-requirements.txt
-    pip install -q -e .
+    pip install -q -e .[oidc]
 else
     . ./venv/bin/activate 
 fi

--- a/scitt_emulator/oidc.py
+++ b/scitt_emulator/oidc.py
@@ -1,0 +1,48 @@
+# Copyright (c) SCITT Authors.
+# Licensed under the MIT License.
+import jwt
+import json
+import jwcrypto.jwk
+from flask import jsonify
+from werkzeug.wrappers import Request
+from scitt_emulator.client import HttpClient
+
+
+class OIDCAuthMiddleware:
+    def __init__(self, app, config_path):
+        self.app = app
+        self.config = {}
+        if config_path and config_path.exists():
+            self.config = json.loads(config_path.read_text())
+
+        # Initialize JSON Web Key client for given issuer
+        self.client = HttpClient()
+        self.oidc_configs = {}
+        self.jwks_clients = {}
+        for issuer in self.config['issuers']:
+            self.oidc_configs[issuer] = self.client.get(
+                f"{issuer}/.well-known/openid-configuration"
+            ).json()
+            self.jwks_clients[issuer] = jwt.PyJWKClient(self.oidc_configs[issuer]["jwks_uri"])
+
+    def __call__(self, environ, start_response):
+        request = Request(environ)
+        self.validate_token(request.headers["Authorization"].replace("Bearer ", ""))
+        return self.app(environ, start_response)
+
+    def validate_token(self, token):
+        validation_error = Exception(f"Failed to validate against all issuers: {self.jwks_clients.keys()!s}")
+        for issuer, jwk_client in self.jwks_clients.items():
+            try:
+                return jwt.decode(
+                    token,
+                    key=jwk_client.get_signing_key_from_jwt(token).key,
+                    algorithms=self.oidc_configs[issuer]["id_token_signing_alg_values_supported"],
+                    audience=self.config.get("audience", None),
+                    issuer=self.oidc_configs[issuer]["issuer"],
+                    options={"strict_aud": self.config.get("strict_aud", True),},
+                    leeway=self.config.get("leeway", 0),
+                )
+            except jwt.PyJWTError as error:
+                validation_error = error
+        raise validation_error

--- a/scitt_emulator/oidc.py
+++ b/scitt_emulator/oidc.py
@@ -3,6 +3,7 @@
 import jwt
 import json
 import jwcrypto.jwk
+import jsonschema
 from flask import jsonify
 from werkzeug.wrappers import Request
 from scitt_emulator.client import HttpClient
@@ -27,7 +28,9 @@ class OIDCAuthMiddleware:
 
     def __call__(self, environ, start_response):
         request = Request(environ)
-        self.validate_token(request.headers["Authorization"].replace("Bearer ", ""))
+        claims = self.validate_token(request.headers["Authorization"].replace("Bearer ", ""))
+        if "claim_schema" in self.config and claims["iss"] in self.config["claim_schema"]:
+            jsonschema.validate(claims, schema=self.config["claim_schema"][claims["iss"]])
         return self.app(environ, start_response)
 
     def validate_token(self, token):

--- a/scitt_emulator/plugin_helpers.py
+++ b/scitt_emulator/plugin_helpers.py
@@ -1,0 +1,36 @@
+# Copyright (c) SCITT Authors.
+# Licensed under the MIT License.
+import os
+import sys
+import pathlib
+import importlib
+from typing import Iterator, Optional, Union, Any
+
+
+def entrypoint_style_load(
+    *args: str, relative: Optional[Union[str, pathlib.Path]] = None
+) -> Iterator[Any]:
+    """
+    Load objects given the entrypoint formatted path to the object. Roughly how
+    the python stdlib docs say entrypoint loading works.
+    """
+    # Push current directory into front of path so we can run things
+    # relative to where we are in the shell
+    if relative is not None:
+        if relative == True:
+            relative = os.getcwd()
+        # str() in case of Path object
+        sys.path.insert(0, str(relative))
+    try:
+        for entry in args:
+            modname, qualname_separator, qualname = entry.partition(":")
+            obj = importlib.import_module(modname)
+            for attr in qualname.split("."):
+                if hasattr(obj, "__getitem__"):
+                    obj = obj[attr]
+                else:
+                    obj = getattr(obj, attr)
+            yield obj
+    finally:
+        if relative is not None:
+            sys.path.pop(0)

--- a/setup.py
+++ b/setup.py
@@ -21,4 +21,10 @@ setup(
         "flask",
         "rkvst-archivist"
     ],
+    extras_require={
+        "oidc": [
+            "PyJWT",
+            "jwcrypto",
+        ]
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         "oidc": [
             "PyJWT",
             "jwcrypto",
+            "jsonschema",
         ]
     },
 )

--- a/tests/test_plugin_helpers.py
+++ b/tests/test_plugin_helpers.py
@@ -1,0 +1,55 @@
+# Copyright (c) SCITT Authors.
+# Licensed under the MIT License.
+import os
+import textwrap
+
+from scitt_emulator.plugin_helpers import entrypoint_style_load
+
+
+def test_entrypoint_style_load_relative(tmp_path):
+    plugin_path = tmp_path / "myplugin.py"
+
+    plugin_path.write_text(
+        textwrap.dedent(
+            """
+            def my_cool_plugin():
+                return "Hello World"
+
+
+            class MyCoolClass:
+                @staticmethod
+                def my_cool_plugin():
+                    return my_cool_plugin()
+
+
+            my_cool_dict = {
+                "my_cool_plugin": my_cool_plugin,
+            }
+            """,
+        )
+    )
+
+    for load_within_file in [
+        "my_cool_plugin",
+        "MyCoolClass.my_cool_plugin",
+        "my_cool_dict.my_cool_plugin",
+    ]:
+        plugin_entrypoint_style_path = (
+            str(plugin_path.relative_to(tmp_path).with_suffix("")).replace(
+                os.path.sep, "."
+            )
+            + ":"
+            + load_within_file
+        )
+
+        loaded = list(
+            entrypoint_style_load(plugin_entrypoint_style_path, relative=tmp_path)
+        )[0]
+
+        os.chdir(tmp_path)
+
+        loaded = list(
+            entrypoint_style_load(plugin_entrypoint_style_path, relative=True)
+        )[0]
+
+        assert loaded() == "Hello World"


### PR DESCRIPTION
- This pull request will add basic OIDC based auth over the claim submission API.
  - OIDC based auth will help us prototype https://slsa.dev style flows.

### [Jump to viewing docs](https://github.com/pdxjohnny/scitt-api-emulator/blob/auth/docs/oidc.md)

- References
  - https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#example-requiring-a-reusable-workflow
  - https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/using-openid-connect-with-reusable-workflows
  - https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#example-requiring-a-reusable-workflow-and-other-claims
  - https://github.com/ietf-wg-scitt/draft-ietf-scitt-architecture/issues/62#issuecomment-1526492830
  - https://github.com/slsa-framework/slsa-github-generator/issues/131
    - https://github.com/actions/runner/issues/2417#issuecomment-1741918395
  - https://openid.net/specs/openid-connect-userinfo-vc-1_0.html#name-userinfo-vc-verification
    - https://github.com/ietf-wg-scitt/draft-ietf-scitt-architecture/issues/87
  - https://github.com/sigstore/fulcio/issues/305
- TODO
  - [x] Auth middleware plugin loader
    - [x] Support for providing config
    - [x] Support for array of issuers
  - [x] Working OIDC auth
    - [x] Refactor `OIDCAuthMiddleware` out of tests into loadable location
    - [x] `jsonschema` based validation of OIDC JWT claims
  - [x] Ensure tests don't get skipped within CI due to module not found errors on OIDC extras
  - [x] Docs for use with GitHub Actions Reusable Workflows
    - [x] Validate docs (see run logs below)
    - [x] asciinema
- Future
  - Use OIDC subject as notary issuer
    - https://github.com/scitt-community/scitt-api-emulator/blob/215777b7ea418f1e0bd54f39cc70467e1fb76b8e/.github/workflows/notarize.yml#L65
  - Expose policy inserted to within feed
    - https://github.com/ietf-scitt/draft-birkholz-scitt-scrapi/pull/2
    - https://github.com/ietf-wg-scitt/draft-ietf-scitt-architecture/issues/11
  - Expose OIDC token to policy engine to match subject?
  - Forges federate feeds from workloads within dependency tree

[![asciicast](https://asciinema.org/a/607600.svg)](https://asciinema.org/a/607600)

<details>
<summary>
GitHub Actions run logs for notarize.yml
</summary>

- https://github.com/pdxjohnny/scitt-api-emulator/actions/runs/6189578017/job/16803962330

```
2023-09-14T18:39:52.8826097Z Requested labels: ubuntu-latest
2023-09-14T18:39:52.8826488Z Job defined at: pdxjohnny/scitt-api-emulator/.github/workflows/notarize.yml@refs/heads/auth
2023-09-14T18:39:52.8826635Z Waiting for a runner to pick up this job...
2023-09-14T18:39:53.2562132Z Job is waiting for a hosted runner to come online.
2023-09-14T18:39:56.7247174Z Job is about to start running on the hosted runner: GitHub Actions 2 (hosted)
2023-09-14T18:39:59.6893355Z Current runner version: '2.309.0'
2023-09-14T18:39:59.6937281Z ##[group]Operating System
2023-09-14T18:39:59.6938287Z Ubuntu
2023-09-14T18:39:59.6938710Z 22.04.3
2023-09-14T18:39:59.6939022Z LTS
2023-09-14T18:39:59.6939405Z ##[endgroup]
2023-09-14T18:39:59.6939822Z ##[group]Runner Image
2023-09-14T18:39:59.6940387Z Image: ubuntu-22.04
2023-09-14T18:39:59.6940830Z Version: 20230911.1.0
2023-09-14T18:39:59.6941872Z Included Software: https://github.com/actions/runner-images/blob/ubuntu22/20230911.1/images/linux/Ubuntu2204-Readme.md
2023-09-14T18:39:59.6942632Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20230911.1
2023-09-14T18:39:59.6943235Z ##[endgroup]
2023-09-14T18:39:59.6943797Z ##[group]Runner Image Provisioner
2023-09-14T18:39:59.6944192Z 2.0.299.1
2023-09-14T18:39:59.6944748Z ##[endgroup]
2023-09-14T18:39:59.6945551Z ##[group]GITHUB_TOKEN Permissions
2023-09-14T18:39:59.6948545Z Metadata: read
2023-09-14T18:39:59.6948929Z ##[endgroup]
2023-09-14T18:39:59.6954075Z Secret source: Actions
2023-09-14T18:39:59.6954982Z Prepare workflow directory
2023-09-14T18:39:59.8402947Z Prepare all required actions
2023-09-14T18:39:59.8673435Z Getting action download info
2023-09-14T18:40:00.1407684Z Download action repository 'actions/checkout@v4' (SHA:3df4ab11eba7bda6032a0b82a6bb43b11571feac)
2023-09-14T18:40:00.7841483Z Download action repository 'actions/setup-python@v4' (SHA:61a6322f88396a6271a6ee3565807d608ecaddd1)
2023-09-14T18:40:01.2650544Z Download action repository 'actions/github-script@v6' (SHA:d7906e4ad0b1822421a7e6a35d5ca353c962f410)
2023-09-14T18:40:01.8806739Z Complete job name: notarize
2023-09-14T18:40:01.9956852Z ##[group]Run if [[ "x${SCITT_URL}" = "x" ]]; then
2023-09-14T18:40:01.9957404Z [36;1mif [[ "x${SCITT_URL}" = "x" ]]; then[0m
2023-09-14T18:40:01.9957903Z [36;1m  echo "SCITT_URL=http://localhost:8080" >> "${GITHUB_ENV}"[0m
2023-09-14T18:40:01.9958303Z [36;1mfi[0m
2023-09-14T18:40:01.9958592Z [36;1mif [[ "x${PAYLOAD}" = "x" ]]; then[0m
2023-09-14T18:40:01.9959187Z [36;1m  echo 'PAYLOAD={"key": "value"}' >> "${GITHUB_ENV}"[0m
2023-09-14T18:40:01.9959572Z [36;1mfi[0m
2023-09-14T18:40:02.0034193Z shell: /usr/bin/bash -e {0}
2023-09-14T18:40:02.0034750Z env:
2023-09-14T18:40:02.0035129Z   SCITT_URL: 
2023-09-14T18:40:02.0035827Z   PAYLOAD: 
2023-09-14T18:40:02.0036179Z ##[endgroup]
2023-09-14T18:40:02.0920311Z ##[group]Run actions/checkout@v4
2023-09-14T18:40:02.0920652Z with:
2023-09-14T18:40:02.0920918Z   repository: pdxjohnny/scitt-api-emulator
2023-09-14T18:40:02.0921386Z   token: ***
2023-09-14T18:40:02.0921618Z   ssh-strict: true
2023-09-14T18:40:02.0921848Z   persist-credentials: true
2023-09-14T18:40:02.0922083Z   clean: true
2023-09-14T18:40:02.0922332Z   sparse-checkout-cone-mode: true
2023-09-14T18:40:02.0922753Z   fetch-depth: 1
2023-09-14T18:40:02.0923058Z   fetch-tags: false
2023-09-14T18:40:02.0923307Z   show-progress: true
2023-09-14T18:40:02.0923520Z   lfs: false
2023-09-14T18:40:02.0923919Z   submodules: false
2023-09-14T18:40:02.0924189Z   set-safe-directory: true
2023-09-14T18:40:02.0924675Z env:
2023-09-14T18:40:02.0925110Z   SCITT_URL: http://localhost:8080
2023-09-14T18:40:02.0925409Z   PAYLOAD: {"key": "value"}
2023-09-14T18:40:02.0925868Z ##[endgroup]
2023-09-14T18:40:02.5022577Z Syncing repository: pdxjohnny/scitt-api-emulator
2023-09-14T18:40:02.5025044Z ##[group]Getting Git version info
2023-09-14T18:40:02.5025662Z Working directory is '/home/runner/work/scitt-api-emulator/scitt-api-emulator'
2023-09-14T18:40:02.5026277Z [command]/usr/bin/git version
2023-09-14T18:40:02.5205333Z git version 2.42.0
2023-09-14T18:40:02.5248929Z ##[endgroup]
2023-09-14T18:40:02.5287554Z Temporarily overriding HOME='/home/runner/work/_temp/b9a8d0c6-4318-40bb-a17d-51e30cbc0587' before making global git config changes
2023-09-14T18:40:02.5288173Z Adding repository directory to the temporary git global config as a safe directory
2023-09-14T18:40:02.5292731Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/scitt-api-emulator/scitt-api-emulator
2023-09-14T18:40:02.5357263Z Deleting the contents of '/home/runner/work/scitt-api-emulator/scitt-api-emulator'
2023-09-14T18:40:02.5361652Z ##[group]Initializing the repository
2023-09-14T18:40:02.5366106Z [command]/usr/bin/git init /home/runner/work/scitt-api-emulator/scitt-api-emulator
2023-09-14T18:40:02.5491258Z hint: Using 'master' as the name for the initial branch. This default branch name
2023-09-14T18:40:02.5492403Z hint: is subject to change. To configure the initial branch name to use in all
2023-09-14T18:40:02.5493289Z hint: of your new repositories, which will suppress this warning, call:
2023-09-14T18:40:02.5494042Z hint: 
2023-09-14T18:40:02.5494755Z hint: 	git config --global init.defaultBranch <name>
2023-09-14T18:40:02.5495194Z hint: 
2023-09-14T18:40:02.5495931Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
2023-09-14T18:40:02.5496612Z hint: 'development'. The just-created branch can be renamed via this command:
2023-09-14T18:40:02.5498325Z hint: 
2023-09-14T18:40:02.5498954Z hint: 	git branch -m <name>
2023-09-14T18:40:02.5518698Z Initialized empty Git repository in /home/runner/work/scitt-api-emulator/scitt-api-emulator/.git/
2023-09-14T18:40:02.5532385Z [command]/usr/bin/git remote add origin https://github.com/pdxjohnny/scitt-api-emulator
2023-09-14T18:40:02.5578387Z ##[endgroup]
2023-09-14T18:40:02.5579181Z ##[group]Disabling automatic garbage collection
2023-09-14T18:40:02.5581702Z [command]/usr/bin/git config --local gc.auto 0
2023-09-14T18:40:02.5620011Z ##[endgroup]
2023-09-14T18:40:02.5620710Z ##[group]Setting up auth
2023-09-14T18:40:02.5627783Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
2023-09-14T18:40:02.5664893Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
2023-09-14T18:40:02.6237393Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2023-09-14T18:40:02.6280598Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
2023-09-14T18:40:02.6669487Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
2023-09-14T18:40:02.6799239Z ##[endgroup]
2023-09-14T18:40:02.6802456Z ##[group]Fetching the repository
2023-09-14T18:40:02.6870597Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +215777b7ea418f1e0bd54f39cc70467e1fb76b8e:refs/remotes/origin/auth
2023-09-14T18:40:03.0860993Z From https://github.com/pdxjohnny/scitt-api-emulator
2023-09-14T18:40:03.0861824Z  * [new ref]         215777b7ea418f1e0bd54f39cc70467e1fb76b8e -> origin/auth
2023-09-14T18:40:03.0863598Z ##[endgroup]
2023-09-14T18:40:03.0864231Z ##[group]Determining the checkout info
2023-09-14T18:40:03.0871388Z ##[endgroup]
2023-09-14T18:40:03.0872310Z ##[group]Checking out the ref
2023-09-14T18:40:03.0873664Z [command]/usr/bin/git checkout --progress --force -B auth refs/remotes/origin/auth
2023-09-14T18:40:03.1042922Z Switched to a new branch 'auth'
2023-09-14T18:40:03.1045124Z branch 'auth' set up to track 'origin/auth'.
2023-09-14T18:40:03.1056672Z ##[endgroup]
2023-09-14T18:40:03.1118324Z [command]/usr/bin/git log -1 --format='%H'
2023-09-14T18:40:03.1142296Z '215777b7ea418f1e0bd54f39cc70467e1fb76b8e'
2023-09-14T18:40:03.1586556Z ##[group]Run actions/setup-python@v4
2023-09-14T18:40:03.1587670Z with:
2023-09-14T18:40:03.1587925Z   python-version: 3.8
2023-09-14T18:40:03.1588226Z   check-latest: false
2023-09-14T18:40:03.1588677Z   token: ***
2023-09-14T18:40:03.1588935Z   update-environment: true
2023-09-14T18:40:03.1589200Z   allow-prereleases: false
2023-09-14T18:40:03.1589444Z env:
2023-09-14T18:40:03.1589701Z   SCITT_URL: http://localhost:8080
2023-09-14T18:40:03.1589975Z   PAYLOAD: {"key": "value"}
2023-09-14T18:40:03.1590537Z ##[endgroup]
2023-09-14T18:40:03.5786622Z ##[group]Installed versions
2023-09-14T18:40:03.5957644Z Successfully set up CPython (3.8.18)
2023-09-14T18:40:03.5958418Z ##[endgroup]
2023-09-14T18:40:03.6041231Z ##[group]Run pip install -U pip setuptools wheel
2023-09-14T18:40:03.6041682Z [36;1mpip install -U pip setuptools wheel[0m
2023-09-14T18:40:03.6042000Z [36;1mpip install .[oidc][0m
2023-09-14T18:40:03.6130679Z shell: /usr/bin/bash -e {0}
2023-09-14T18:40:03.6130941Z env:
2023-09-14T18:40:03.6131198Z   SCITT_URL: http://localhost:8080
2023-09-14T18:40:03.6131671Z   PAYLOAD: {"key": "value"}
2023-09-14T18:40:03.6132164Z   pythonLocation: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:03.6132533Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.8.18/x64/lib/pkgconfig
2023-09-14T18:40:03.6133014Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:03.6133370Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:03.6133726Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:03.6134081Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.8.18/x64/lib
2023-09-14T18:40:03.6134366Z ##[endgroup]
2023-09-14T18:40:07.3880300Z Requirement already satisfied: pip in /opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages (23.0.1)
2023-09-14T18:40:07.7208153Z Collecting pip
2023-09-14T18:40:07.7211052Z   Obtaining dependency information for pip from https://files.pythonhosted.org/packages/50/c2/e06851e8cc28dcad7c155f4753da8833ac06a5c704c109313b8d5a62968a/pip-23.2.1-py3-none-any.whl.metadata
2023-09-14T18:40:07.8887688Z   Downloading pip-23.2.1-py3-none-any.whl.metadata (4.2 kB)
2023-09-14T18:40:07.8934470Z Requirement already satisfied: setuptools in /opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages (56.0.0)
2023-09-14T18:40:08.3331260Z Collecting setuptools
2023-09-14T18:40:08.3334818Z   Obtaining dependency information for setuptools from https://files.pythonhosted.org/packages/bb/26/7945080113158354380a12ce26873dd6c1ebd88d47f5bc24e2c5bb38c16a/setuptools-68.2.2-py3-none-any.whl.metadata
2023-09-14T18:40:08.3507540Z   Downloading setuptools-68.2.2-py3-none-any.whl.metadata (6.3 kB)
2023-09-14T18:40:08.4298152Z Collecting wheel
2023-09-14T18:40:08.4304045Z   Obtaining dependency information for wheel from https://files.pythonhosted.org/packages/b8/8b/31273bf66016be6ad22bb7345c37ff350276cfd46e389a0c2ac5da9d9073/wheel-0.41.2-py3-none-any.whl.metadata
2023-09-14T18:40:08.4511204Z   Downloading wheel-0.41.2-py3-none-any.whl.metadata (2.2 kB)
2023-09-14T18:40:08.5461638Z Downloading pip-23.2.1-py3-none-any.whl (2.1 MB)
2023-09-14T18:40:08.6656895Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.1/2.1 MB 18.5 MB/s eta 0:00:00
2023-09-14T18:40:08.6846245Z Downloading setuptools-68.2.2-py3-none-any.whl (807 kB)
2023-09-14T18:40:08.7013687Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 807.9/807.9 kB 62.9 MB/s eta 0:00:00
2023-09-14T18:40:08.7187387Z Downloading wheel-0.41.2-py3-none-any.whl (64 kB)
2023-09-14T18:40:08.7257292Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 64.8/64.8 kB 13.7 MB/s eta 0:00:00
2023-09-14T18:40:08.8913077Z Installing collected packages: wheel, setuptools, pip
2023-09-14T18:40:08.9595333Z   Attempting uninstall: setuptools
2023-09-14T18:40:08.9604589Z     Found existing installation: setuptools 56.0.0
2023-09-14T18:40:09.0054557Z     Uninstalling setuptools-56.0.0:
2023-09-14T18:40:09.0203919Z       Successfully uninstalled setuptools-56.0.0
2023-09-14T18:40:09.6221004Z   Attempting uninstall: pip
2023-09-14T18:40:09.6237798Z     Found existing installation: pip 23.0.1
2023-09-14T18:40:09.7147665Z     Uninstalling pip-23.0.1:
2023-09-14T18:40:09.7848518Z       Successfully uninstalled pip-23.0.1
2023-09-14T18:40:11.3265058Z Successfully installed pip-23.2.1 setuptools-68.2.2 wheel-0.41.2
2023-09-14T18:40:12.4079480Z Processing /home/runner/work/scitt-api-emulator/scitt-api-emulator
2023-09-14T18:40:12.4093945Z   Preparing metadata (setup.py): started
2023-09-14T18:40:12.7550414Z   Preparing metadata (setup.py): finished with status 'done'
2023-09-14T18:40:13.4739270Z Collecting cryptography (from scitt-emulator==0.0.1)
2023-09-14T18:40:13.4741962Z   Obtaining dependency information for cryptography from https://files.pythonhosted.org/packages/46/74/f9eba8c947f57991b5dd5e45797fdc68cc70e444c32e6b952b512d42aba5/cryptography-41.0.3-cp37-abi3-manylinux_2_28_x86_64.whl.metadata
2023-09-14T18:40:13.6172533Z   Downloading cryptography-41.0.3-cp37-abi3-manylinux_2_28_x86_64.whl.metadata (5.2 kB)
2023-09-14T18:40:13.7123605Z Collecting cbor2 (from scitt-emulator==0.0.1)
2023-09-14T18:40:13.7316670Z   Downloading cbor2-5.4.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (236 kB)
2023-09-14T18:40:13.7976505Z      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 236.3/236.3 kB 4.4 MB/s eta 0:00:00
2023-09-14T18:40:13.8361216Z Collecting pycose (from scitt-emulator==0.0.1)
2023-09-14T18:40:13.8545350Z   Downloading pycose-1.0.1-py3-none-any.whl (48 kB)
2023-09-14T18:40:13.8638225Z      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.8/48.8 kB 7.2 MB/s eta 0:00:00
2023-09-14T18:40:13.9338042Z Collecting httpx (from scitt-emulator==0.0.1)
2023-09-14T18:40:13.9344272Z   Obtaining dependency information for httpx from https://files.pythonhosted.org/packages/33/0d/d9ce469af019741c8999711d36b270ff992ceb1a0293f73f9f34fdf131e9/httpx-0.25.0-py3-none-any.whl.metadata
2023-09-14T18:40:13.9518989Z   Downloading httpx-0.25.0-py3-none-any.whl.metadata (7.6 kB)
2023-09-14T18:40:14.0136407Z Collecting flask (from scitt-emulator==0.0.1)
2023-09-14T18:40:14.0143151Z   Obtaining dependency information for flask from https://files.pythonhosted.org/packages/fd/56/26f0be8adc2b4257df20c1c4260ddd0aa396cf8e75d90ab2f7ff99bc34f9/flask-2.3.3-py3-none-any.whl.metadata
2023-09-14T18:40:14.0321576Z   Downloading flask-2.3.3-py3-none-any.whl.metadata (3.6 kB)
2023-09-14T18:40:14.0780045Z Collecting rkvst-archivist (from scitt-emulator==0.0.1)
2023-09-14T18:40:14.0783567Z   Obtaining dependency information for rkvst-archivist from https://files.pythonhosted.org/packages/57/16/09d231417e4347f80fd191e8d45c5fbbd434f4bd60529b542bb1a1292fef/rkvst_archivist-0.25.2-py2.py3-none-any.whl.metadata
2023-09-14T18:40:14.0971325Z   Downloading rkvst_archivist-0.25.2-py2.py3-none-any.whl.metadata (13 kB)
2023-09-14T18:40:14.1620906Z Collecting PyJWT (from scitt-emulator==0.0.1)
2023-09-14T18:40:14.1628047Z   Obtaining dependency information for PyJWT from https://files.pythonhosted.org/packages/2b/4f/e04a8067c7c96c364cef7ef73906504e2f40d690811c021e1a1901473a19/PyJWT-2.8.0-py3-none-any.whl.metadata
2023-09-14T18:40:14.1813608Z   Downloading PyJWT-2.8.0-py3-none-any.whl.metadata (4.2 kB)
2023-09-14T18:40:14.2236712Z Collecting jwcrypto (from scitt-emulator==0.0.1)
2023-09-14T18:40:14.2439046Z   Downloading jwcrypto-1.5.0.tar.gz (86 kB)
2023-09-14T18:40:14.2512715Z      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 86.4/86.4 kB 20.1 MB/s eta 0:00:00
2023-09-14T18:40:14.2665169Z   Preparing metadata (setup.py): started
2023-09-14T18:40:14.4884481Z   Preparing metadata (setup.py): finished with status 'done'
2023-09-14T18:40:14.5722077Z Collecting jsonschema (from scitt-emulator==0.0.1)
2023-09-14T18:40:14.5729849Z   Obtaining dependency information for jsonschema from https://files.pythonhosted.org/packages/2b/ff/af59fd34bc4d7ac3e6e0cd1f3c10317d329b6c1aee179e8b24ad9a79fbac/jsonschema-4.19.0-py3-none-any.whl.metadata
2023-09-14T18:40:14.5927656Z   Downloading jsonschema-4.19.0-py3-none-any.whl.metadata (8.2 kB)
2023-09-14T18:40:14.9911255Z Collecting cffi>=1.12 (from cryptography->scitt-emulator==0.0.1)
2023-09-14T18:40:15.0166838Z   Downloading cffi-1.15.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (442 kB)
2023-09-14T18:40:15.0377520Z      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 442.7/442.7 kB 26.5 MB/s eta 0:00:00
2023-09-14T18:40:15.1264331Z Collecting Werkzeug>=2.3.7 (from flask->scitt-emulator==0.0.1)
2023-09-14T18:40:15.1265513Z   Obtaining dependency information for Werkzeug>=2.3.7 from https://files.pythonhosted.org/packages/9b/59/a7c32e3d8d0e546a206e0552a2c04444544f15c1da4a01df8938d20c6ffc/werkzeug-2.3.7-py3-none-any.whl.metadata
2023-09-14T18:40:15.1443958Z   Downloading werkzeug-2.3.7-py3-none-any.whl.metadata (4.1 kB)
2023-09-14T18:40:15.2013695Z Collecting Jinja2>=3.1.2 (from flask->scitt-emulator==0.0.1)
2023-09-14T18:40:15.2184981Z   Downloading Jinja2-3.1.2-py3-none-any.whl (133 kB)
2023-09-14T18:40:15.2261243Z      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 133.1/133.1 kB 29.6 MB/s eta 0:00:00
2023-09-14T18:40:15.2657675Z Collecting itsdangerous>=2.1.2 (from flask->scitt-emulator==0.0.1)
2023-09-14T18:40:15.2834770Z   Downloading itsdangerous-2.1.2-py3-none-any.whl (15 kB)
2023-09-14T18:40:15.3440733Z Collecting click>=8.1.3 (from flask->scitt-emulator==0.0.1)
2023-09-14T18:40:15.3443976Z   Obtaining dependency information for click>=8.1.3 from https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl.metadata
2023-09-14T18:40:15.3623038Z   Downloading click-8.1.7-py3-none-any.whl.metadata (3.0 kB)
2023-09-14T18:40:15.4019875Z Collecting blinker>=1.6.2 (from flask->scitt-emulator==0.0.1)
2023-09-14T18:40:15.4208170Z   Downloading blinker-1.6.2-py3-none-any.whl (13 kB)
2023-09-14T18:40:15.5574427Z Collecting importlib-metadata>=3.6.0 (from flask->scitt-emulator==0.0.1)
2023-09-14T18:40:15.5581000Z   Obtaining dependency information for importlib-metadata>=3.6.0 from https://files.pythonhosted.org/packages/cc/37/db7ba97e676af155f5fcb1a35466f446eadc9104e25b83366e8088c9c926/importlib_metadata-6.8.0-py3-none-any.whl.metadata
2023-09-14T18:40:15.5759519Z   Downloading importlib_metadata-6.8.0-py3-none-any.whl.metadata (5.1 kB)
2023-09-14T18:40:15.6522607Z Collecting certifi (from httpx->scitt-emulator==0.0.1)
2023-09-14T18:40:15.6525089Z   Obtaining dependency information for certifi from https://files.pythonhosted.org/packages/4c/dd/2234eab22353ffc7d94e8d13177aaa050113286e93e7b40eae01fbf7c3d9/certifi-2023.7.22-py3-none-any.whl.metadata
2023-09-14T18:40:15.6702061Z   Downloading certifi-2023.7.22-py3-none-any.whl.metadata (2.2 kB)
2023-09-14T18:40:15.7391378Z Collecting httpcore<0.19.0,>=0.18.0 (from httpx->scitt-emulator==0.0.1)
2023-09-14T18:40:15.7394176Z   Obtaining dependency information for httpcore<0.19.0,>=0.18.0 from https://files.pythonhosted.org/packages/ac/97/724afbb7925339f6214bf1fdb5714d1a462690466832bf8fb3fd497649f1/httpcore-0.18.0-py3-none-any.whl.metadata
2023-09-14T18:40:15.7568615Z   Downloading httpcore-0.18.0-py3-none-any.whl.metadata (18 kB)
2023-09-14T18:40:15.8001979Z Collecting idna (from httpx->scitt-emulator==0.0.1)
2023-09-14T18:40:15.8174421Z   Downloading idna-3.4-py3-none-any.whl (61 kB)
2023-09-14T18:40:15.8258741Z      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 61.5/61.5 kB 10.2 MB/s eta 0:00:00
2023-09-14T18:40:15.8584344Z Collecting sniffio (from httpx->scitt-emulator==0.0.1)
2023-09-14T18:40:15.8756900Z   Downloading sniffio-1.3.0-py3-none-any.whl (10 kB)
2023-09-14T18:40:15.9605156Z Collecting attrs>=22.2.0 (from jsonschema->scitt-emulator==0.0.1)
2023-09-14T18:40:15.9776153Z   Downloading attrs-23.1.0-py3-none-any.whl (61 kB)
2023-09-14T18:40:15.9851665Z      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 61.2/61.2 kB 13.2 MB/s eta 0:00:00
2023-09-14T18:40:16.1392957Z Collecting importlib-resources>=1.4.0 (from jsonschema->scitt-emulator==0.0.1)
2023-09-14T18:40:16.1395469Z   Obtaining dependency information for importlib-resources>=1.4.0 from https://files.pythonhosted.org/packages/25/d4/592f53ce2f8dde8be5720851bd0ab71cc2e76c55978e4163ef1ab7e389bb/importlib_resources-6.0.1-py3-none-any.whl.metadata
2023-09-14T18:40:16.1572688Z   Downloading importlib_resources-6.0.1-py3-none-any.whl.metadata (4.0 kB)
2023-09-14T18:40:16.2084592Z Collecting jsonschema-specifications>=2023.03.6 (from jsonschema->scitt-emulator==0.0.1)
2023-09-14T18:40:16.2092157Z   Obtaining dependency information for jsonschema-specifications>=2023.03.6 from https://files.pythonhosted.org/packages/1c/24/83349ac2189cc2435e84da3f69ba3c97314d3c0622628e55171c6798ed80/jsonschema_specifications-2023.7.1-py3-none-any.whl.metadata
2023-09-14T18:40:16.2270665Z   Downloading jsonschema_specifications-2023.7.1-py3-none-any.whl.metadata (2.8 kB)
2023-09-14T18:40:16.2664762Z Collecting pkgutil-resolve-name>=1.3.10 (from jsonschema->scitt-emulator==0.0.1)
2023-09-14T18:40:16.2839167Z   Downloading pkgutil_resolve_name-1.3.10-py3-none-any.whl (4.7 kB)
2023-09-14T18:40:16.4028122Z Collecting referencing>=0.28.4 (from jsonschema->scitt-emulator==0.0.1)
2023-09-14T18:40:16.4031006Z   Obtaining dependency information for referencing>=0.28.4 from https://files.pythonhosted.org/packages/be/8e/56d6f1e2d591f4d6cbcba446cac4a1b0dc4f584537e2071d9bcee8eeab6b/referencing-0.30.2-py3-none-any.whl.metadata
2023-09-14T18:40:16.4203234Z   Downloading referencing-0.30.2-py3-none-any.whl.metadata (2.6 kB)
2023-09-14T18:40:16.8153872Z Collecting rpds-py>=0.7.1 (from jsonschema->scitt-emulator==0.0.1)
2023-09-14T18:40:16.8156370Z   Obtaining dependency information for rpds-py>=0.7.1 from https://files.pythonhosted.org/packages/c2/e6/bdd47feb6967fcc9dab041fefa70ee537898fbec89618e7e190fc648e2e3/rpds_py-0.10.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata
2023-09-14T18:40:16.8336433Z   Downloading rpds_py-0.10.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (3.7 kB)
2023-09-14T18:40:16.9125841Z Collecting deprecated (from jwcrypto->scitt-emulator==0.0.1)
2023-09-14T18:40:16.9128136Z   Obtaining dependency information for deprecated from https://files.pythonhosted.org/packages/20/8d/778b7d51b981a96554f29136cd59ca7880bf58094338085bcf2a979a0e6a/Deprecated-1.2.14-py2.py3-none-any.whl.metadata
2023-09-14T18:40:16.9302986Z   Downloading Deprecated-1.2.14-py2.py3-none-any.whl.metadata (5.4 kB)
2023-09-14T18:40:17.0013009Z Collecting ecdsa (from pycose->scitt-emulator==0.0.1)
2023-09-14T18:40:17.0194833Z   Downloading ecdsa-0.18.0-py2.py3-none-any.whl (142 kB)
2023-09-14T18:40:17.0291424Z      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 142.9/142.9 kB 24.6 MB/s eta 0:00:00
2023-09-14T18:40:17.0669766Z Collecting certvalidator (from pycose->scitt-emulator==0.0.1)
2023-09-14T18:40:17.0850000Z   Downloading certvalidator-0.11.1-py2.py3-none-any.whl (31 kB)
2023-09-14T18:40:17.1711418Z Collecting backoff~=2.2.1 (from rkvst-archivist->scitt-emulator==0.0.1)
2023-09-14T18:40:17.1899180Z   Downloading backoff-2.2.1-py3-none-any.whl (15 kB)
2023-09-14T18:40:17.2529786Z Collecting flatten-dict~=0.4 (from rkvst-archivist->scitt-emulator==0.0.1)
2023-09-14T18:40:17.2720634Z   Downloading flatten_dict-0.4.2-py2.py3-none-any.whl (9.7 kB)
2023-09-14T18:40:17.3188450Z Collecting iso8601~=2.0 (from rkvst-archivist->scitt-emulator==0.0.1)
2023-09-14T18:40:17.3196864Z   Obtaining dependency information for iso8601~=2.0 from https://files.pythonhosted.org/packages/12/e4/032a8569b75a79057f0c72b4f4a69434fd21922bce7bfe054e0e9f367861/iso8601-2.0.0-py3-none-any.whl.metadata
2023-09-14T18:40:17.3405383Z   Downloading iso8601-2.0.0-py3-none-any.whl.metadata (3.6 kB)
2023-09-14T18:40:17.3966889Z Collecting pyaml-env~=1.2 (from rkvst-archivist->scitt-emulator==0.0.1)
2023-09-14T18:40:17.4156329Z   Downloading pyaml_env-1.2.1-py3-none-any.whl (9.0 kB)
2023-09-14T18:40:17.5102962Z Collecting requests~=2.31.0 (from rkvst-archivist->scitt-emulator==0.0.1)
2023-09-14T18:40:17.5110930Z   Obtaining dependency information for requests~=2.31.0 from https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl.metadata
2023-09-14T18:40:17.5293262Z   Downloading requests-2.31.0-py3-none-any.whl.metadata (4.6 kB)
2023-09-14T18:40:17.5759094Z Collecting requests-toolbelt~=1.0 (from rkvst-archivist->scitt-emulator==0.0.1)
2023-09-14T18:40:17.5974903Z   Downloading requests_toolbelt-1.0.0-py2.py3-none-any.whl (54 kB)
2023-09-14T18:40:17.6046937Z      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 54.5/54.5 kB 14.0 MB/s eta 0:00:00
2023-09-14T18:40:17.6404195Z Collecting rfc3339~=6.2 (from rkvst-archivist->scitt-emulator==0.0.1)
2023-09-14T18:40:17.6589575Z   Downloading rfc3339-6.2-py3-none-any.whl (5.5 kB)
2023-09-14T18:40:17.7041844Z Collecting xmltodict~=0.13 (from rkvst-archivist->scitt-emulator==0.0.1)
2023-09-14T18:40:17.7213350Z   Downloading xmltodict-0.13.0-py2.py3-none-any.whl (10.0 kB)
2023-09-14T18:40:17.8076204Z Collecting pycparser (from cffi>=1.12->cryptography->scitt-emulator==0.0.1)
2023-09-14T18:40:17.8303270Z   Downloading pycparser-2.21-py2.py3-none-any.whl (118 kB)
2023-09-14T18:40:17.8384501Z      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 118.7/118.7 kB 25.0 MB/s eta 0:00:00
2023-09-14T18:40:17.8985399Z Collecting six<2.0,>=1.12 (from flatten-dict~=0.4->rkvst-archivist->scitt-emulator==0.0.1)
2023-09-14T18:40:17.9161066Z   Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
2023-09-14T18:40:18.0016398Z Collecting anyio<5.0,>=3.0 (from httpcore<0.19.0,>=0.18.0->httpx->scitt-emulator==0.0.1)
2023-09-14T18:40:18.0020635Z   Obtaining dependency information for anyio<5.0,>=3.0 from https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl.metadata
2023-09-14T18:40:18.0242821Z   Downloading anyio-4.0.0-py3-none-any.whl.metadata (4.5 kB)
2023-09-14T18:40:18.0638568Z Collecting h11<0.15,>=0.13 (from httpcore<0.19.0,>=0.18.0->httpx->scitt-emulator==0.0.1)
2023-09-14T18:40:18.0820683Z   Downloading h11-0.14.0-py3-none-any.whl (58 kB)
2023-09-14T18:40:18.0895420Z      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 58.3/58.3 kB 12.3 MB/s eta 0:00:00
2023-09-14T18:40:18.1982507Z Collecting zipp>=0.5 (from importlib-metadata>=3.6.0->flask->scitt-emulator==0.0.1)
2023-09-14T18:40:18.1985976Z   Obtaining dependency information for zipp>=0.5 from https://files.pythonhosted.org/packages/8c/08/d3006317aefe25ea79d3b76c9650afabaf6d63d1c8443b236e7405447503/zipp-3.16.2-py3-none-any.whl.metadata
2023-09-14T18:40:18.2164391Z   Downloading zipp-3.16.2-py3-none-any.whl.metadata (3.7 kB)
2023-09-14T18:40:18.4085927Z Collecting MarkupSafe>=2.0 (from Jinja2>=3.1.2->flask->scitt-emulator==0.0.1)
2023-09-14T18:40:18.4089597Z   Obtaining dependency information for MarkupSafe>=2.0 from https://files.pythonhosted.org/packages/de/e2/32c14301bb023986dff527a49325b6259cab4ebb4633f69de54af312fc45/MarkupSafe-2.1.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata
2023-09-14T18:40:18.4281908Z   Downloading MarkupSafe-2.1.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (3.0 kB)
2023-09-14T18:40:18.5971794Z Collecting PyYAML<=7.0,>=5.0 (from pyaml-env~=1.2->rkvst-archivist->scitt-emulator==0.0.1)
2023-09-14T18:40:18.5980770Z   Obtaining dependency information for PyYAML<=7.0,>=5.0 from https://files.pythonhosted.org/packages/c8/6b/6600ac24725c7388255b2f5add93f91e58a5d7efaf4af244fdbcc11a541b/PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata
2023-09-14T18:40:18.6158920Z   Downloading PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (2.1 kB)
2023-09-14T18:40:18.8638292Z Collecting charset-normalizer<4,>=2 (from requests~=2.31.0->rkvst-archivist->scitt-emulator==0.0.1)
2023-09-14T18:40:18.8641380Z   Obtaining dependency information for charset-normalizer<4,>=2 from https://files.pythonhosted.org/packages/cb/e7/5e43745003bf1f90668c7be23fc5952b3a2b9c2558f16749411c18039b36/charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata
2023-09-14T18:40:18.8823193Z   Downloading charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (31 kB)
2023-09-14T18:40:18.9926219Z Collecting urllib3<3,>=1.21.1 (from requests~=2.31.0->rkvst-archivist->scitt-emulator==0.0.1)
2023-09-14T18:40:18.9932995Z   Obtaining dependency information for urllib3<3,>=1.21.1 from https://files.pythonhosted.org/packages/9b/81/62fd61001fa4b9d0df6e31d47ff49cfa9de4af03adecf339c7bc30656b37/urllib3-2.0.4-py3-none-any.whl.metadata
2023-09-14T18:40:19.0137217Z   Downloading urllib3-2.0.4-py3-none-any.whl.metadata (6.6 kB)
2023-09-14T18:40:19.2438431Z Collecting asn1crypto>=0.18.1 (from certvalidator->pycose->scitt-emulator==0.0.1)
2023-09-14T18:40:19.2621157Z   Downloading asn1crypto-1.5.1-py2.py3-none-any.whl (105 kB)
2023-09-14T18:40:19.2737036Z      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 105.0/105.0 kB 20.8 MB/s eta 0:00:00
2023-09-14T18:40:19.3142387Z Collecting oscrypto>=0.16.1 (from certvalidator->pycose->scitt-emulator==0.0.1)
2023-09-14T18:40:19.3341934Z   Downloading oscrypto-1.3.0-py2.py3-none-any.whl (194 kB)
2023-09-14T18:40:19.3434467Z      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 194.6/194.6 kB 35.9 MB/s eta 0:00:00
2023-09-14T18:40:19.5957352Z Collecting wrapt<2,>=1.10 (from deprecated->jwcrypto->scitt-emulator==0.0.1)
2023-09-14T18:40:19.6142849Z   Downloading wrapt-1.15.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (81 kB)
2023-09-14T18:40:19.6215428Z      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 81.5/81.5 kB 19.3 MB/s eta 0:00:00
2023-09-14T18:40:19.7403428Z Collecting exceptiongroup>=1.0.2 (from anyio<5.0,>=3.0->httpcore<0.19.0,>=0.18.0->httpx->scitt-emulator==0.0.1)
2023-09-14T18:40:19.7408577Z   Obtaining dependency information for exceptiongroup>=1.0.2 from https://files.pythonhosted.org/packages/ad/83/b71e58666f156a39fb29417e4c8ca4bc7400c0dd4ed9e8842ab54dc8c344/exceptiongroup-1.1.3-py3-none-any.whl.metadata
2023-09-14T18:40:19.7586965Z   Downloading exceptiongroup-1.1.3-py3-none-any.whl.metadata (6.1 kB)
2023-09-14T18:40:20.0089964Z Downloading cryptography-41.0.3-cp37-abi3-manylinux_2_28_x86_64.whl (4.3 MB)
2023-09-14T18:40:20.0823682Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.3/4.3 MB 62.7 MB/s eta 0:00:00
2023-09-14T18:40:20.1007354Z Downloading flask-2.3.3-py3-none-any.whl (96 kB)
2023-09-14T18:40:20.1123409Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 96.1/96.1 kB 11.4 MB/s eta 0:00:00
2023-09-14T18:40:20.1301081Z Downloading httpx-0.25.0-py3-none-any.whl (75 kB)
2023-09-14T18:40:20.1384053Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 75.7/75.7 kB 16.6 MB/s eta 0:00:00
2023-09-14T18:40:20.1564504Z Downloading jsonschema-4.19.0-py3-none-any.whl (83 kB)
2023-09-14T18:40:20.1646399Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 83.4/83.4 kB 18.9 MB/s eta 0:00:00
2023-09-14T18:40:20.1824603Z Downloading PyJWT-2.8.0-py3-none-any.whl (22 kB)
2023-09-14T18:40:20.2073331Z Downloading rkvst_archivist-0.25.2-py2.py3-none-any.whl (61 kB)
2023-09-14T18:40:20.2161473Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 61.9/61.9 kB 10.7 MB/s eta 0:00:00
2023-09-14T18:40:20.2355668Z Downloading click-8.1.7-py3-none-any.whl (97 kB)
2023-09-14T18:40:20.2428525Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 97.9/97.9 kB 22.3 MB/s eta 0:00:00
2023-09-14T18:40:20.2604795Z Downloading httpcore-0.18.0-py3-none-any.whl (76 kB)
2023-09-14T18:40:20.2688513Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 76.0/76.0 kB 15.7 MB/s eta 0:00:00
2023-09-14T18:40:20.2871425Z Downloading importlib_metadata-6.8.0-py3-none-any.whl (22 kB)
2023-09-14T18:40:20.3090670Z Downloading importlib_resources-6.0.1-py3-none-any.whl (34 kB)
2023-09-14T18:40:20.3303432Z Downloading iso8601-2.0.0-py3-none-any.whl (7.5 kB)
2023-09-14T18:40:20.3511047Z Downloading jsonschema_specifications-2023.7.1-py3-none-any.whl (17 kB)
2023-09-14T18:40:20.3715703Z Downloading referencing-0.30.2-py3-none-any.whl (25 kB)
2023-09-14T18:40:20.3917657Z Downloading requests-2.31.0-py3-none-any.whl (62 kB)
2023-09-14T18:40:20.3984602Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 62.6/62.6 kB 16.7 MB/s eta 0:00:00
2023-09-14T18:40:20.4159089Z Downloading certifi-2023.7.22-py3-none-any.whl (158 kB)
2023-09-14T18:40:20.4252760Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 158.3/158.3 kB 26.0 MB/s eta 0:00:00
2023-09-14T18:40:20.4463595Z Downloading rpds_py-0.10.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.2 MB)
2023-09-14T18:40:20.4691769Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 65.7 MB/s eta 0:00:00
2023-09-14T18:40:20.4869615Z Downloading werkzeug-2.3.7-py3-none-any.whl (242 kB)
2023-09-14T18:40:20.4963613Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 242.2/242.2 kB 40.7 MB/s eta 0:00:00
2023-09-14T18:40:20.5143261Z Downloading Deprecated-1.2.14-py2.py3-none-any.whl (9.6 kB)
2023-09-14T18:40:20.5352084Z Downloading anyio-4.0.0-py3-none-any.whl (83 kB)
2023-09-14T18:40:20.5428594Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 83.1/83.1 kB 19.2 MB/s eta 0:00:00
2023-09-14T18:40:20.5604870Z Downloading charset_normalizer-3.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (199 kB)
2023-09-14T18:40:20.5694750Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 199.1/199.1 kB 34.5 MB/s eta 0:00:00
2023-09-14T18:40:20.5874460Z Downloading MarkupSafe-2.1.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (25 kB)
2023-09-14T18:40:20.6081765Z Downloading PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (736 kB)
2023-09-14T18:40:20.6233308Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 736.6/736.6 kB 62.7 MB/s eta 0:00:00
2023-09-14T18:40:20.6412146Z Downloading urllib3-2.0.4-py3-none-any.whl (123 kB)
2023-09-14T18:40:20.6501379Z    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 123.9/123.9 kB 25.0 MB/s eta 0:00:00
2023-09-14T18:40:20.6675627Z Downloading zipp-3.16.2-py3-none-any.whl (7.2 kB)
2023-09-14T18:40:20.6931645Z Downloading exceptiongroup-1.1.3-py3-none-any.whl (14 kB)
2023-09-14T18:40:20.7671277Z Building wheels for collected packages: jwcrypto, scitt-emulator
2023-09-14T18:40:20.7678825Z   Building wheel for jwcrypto (setup.py): started
2023-09-14T18:40:21.3049776Z   Building wheel for jwcrypto (setup.py): finished with status 'done'
2023-09-14T18:40:21.3058188Z   Created wheel for jwcrypto: filename=jwcrypto-1.5.0-py3-none-any.whl size=91726 sha256=3b2092ba3cd8474869a26d396ffae3bbc02181c2d023f195a66093739d7e44c1
2023-09-14T18:40:21.3061692Z   Stored in directory: /home/runner/.cache/pip/wheels/7f/1e/cf/15a127c9af6615f5ca6c5e4c7642cdfaff40fa8b5700d582c2
2023-09-14T18:40:21.3105320Z   Building wheel for scitt-emulator (setup.py): started
2023-09-14T18:40:21.6099529Z   Building wheel for scitt-emulator (setup.py): finished with status 'done'
2023-09-14T18:40:21.6110907Z   Created wheel for scitt-emulator: filename=scitt_emulator-0.0.1-py3-none-any.whl size=24211 sha256=ad3c0868f95541dbc08529ae5c0982afe535800e8173c133c9812ec79b5aa6e9
2023-09-14T18:40:21.6117801Z   Stored in directory: /home/runner/.cache/pip/wheels/e4/c5/d1/75e164092c680e6269f524b13aeac6a85dcf268f4b62e66ab3
2023-09-14T18:40:21.6154247Z Successfully built jwcrypto scitt-emulator
2023-09-14T18:40:22.0582816Z Installing collected packages: rfc3339, asn1crypto, zipp, xmltodict, wrapt, urllib3, sniffio, six, rpds-py, PyYAML, PyJWT, pycparser, pkgutil-resolve-name, oscrypto, MarkupSafe, itsdangerous, iso8601, idna, h11, exceptiongroup, click, charset-normalizer, certifi, cbor2, blinker, backoff, attrs, Werkzeug, requests, referencing, pyaml-env, Jinja2, importlib-resources, importlib-metadata, flatten-dict, ecdsa, deprecated, cffi, certvalidator, anyio, requests-toolbelt, jsonschema-specifications, httpcore, flask, cryptography, rkvst-archivist, pycose, jwcrypto, jsonschema, httpx, scitt-emulator
2023-09-14T18:40:24.9482804Z Successfully installed Jinja2-3.1.2 MarkupSafe-2.1.3 PyJWT-2.8.0 PyYAML-6.0.1 Werkzeug-2.3.7 anyio-4.0.0 asn1crypto-1.5.1 attrs-23.1.0 backoff-2.2.1 blinker-1.6.2 cbor2-5.4.6 certifi-2023.7.22 certvalidator-0.11.1 cffi-1.15.1 charset-normalizer-3.2.0 click-8.1.7 cryptography-41.0.3 deprecated-1.2.14 ecdsa-0.18.0 exceptiongroup-1.1.3 flask-2.3.3 flatten-dict-0.4.2 h11-0.14.0 httpcore-0.18.0 httpx-0.25.0 idna-3.4 importlib-metadata-6.8.0 importlib-resources-6.0.1 iso8601-2.0.0 itsdangerous-2.1.2 jsonschema-4.19.0 jsonschema-specifications-2023.7.1 jwcrypto-1.5.0 oscrypto-1.3.0 pkgutil-resolve-name-1.3.10 pyaml-env-1.2.1 pycose-1.0.1 pycparser-2.21 referencing-0.30.2 requests-2.31.0 requests-toolbelt-1.0.0 rfc3339-6.2 rkvst-archivist-0.25.2 rpds-py-0.10.3 scitt-emulator-0.0.1 six-1.16.0 sniffio-1.3.0 urllib3-2.0.4 wrapt-1.15.0 xmltodict-0.13.0 zipp-3.16.2
2023-09-14T18:40:25.2915378Z ##[group]Run npm install @actions/core
2023-09-14T18:40:25.2915745Z [36;1mnpm install @actions/core[0m
2023-09-14T18:40:25.2983338Z shell: /usr/bin/bash -e {0}
2023-09-14T18:40:25.2983643Z env:
2023-09-14T18:40:25.2983920Z   SCITT_URL: http://localhost:8080
2023-09-14T18:40:25.2984230Z   PAYLOAD: {"key": "value"}
2023-09-14T18:40:25.2984576Z   pythonLocation: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:25.2984990Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.8.18/x64/lib/pkgconfig
2023-09-14T18:40:25.2985379Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:25.2985758Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:25.2986144Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:25.2986513Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.8.18/x64/lib
2023-09-14T18:40:25.2986995Z ##[endgroup]
2023-09-14T18:40:30.4215643Z 
2023-09-14T18:40:30.4216320Z added 4 packages in 3s
2023-09-14T18:40:30.4414660Z ##[group]Run actions/github-script@v6
2023-09-14T18:40:30.4414966Z with:
2023-09-14T18:40:30.4415300Z   script: const {SCITT_URL} = process.env;
core.setOutput('token', await core.getIDToken(SCITT_URL));

2023-09-14T18:40:30.4415789Z   github-token: ***
2023-09-14T18:40:30.4415988Z   debug: false
2023-09-14T18:40:30.4416218Z   user-agent: actions/github-script
2023-09-14T18:40:30.4416461Z   result-encoding: json
2023-09-14T18:40:30.4416660Z   retries: 0
2023-09-14T18:40:30.4416905Z   retry-exempt-status-codes: 400,401,403,404,422
2023-09-14T18:40:30.4417145Z env:
2023-09-14T18:40:30.4417362Z   SCITT_URL: http://localhost:8080
2023-09-14T18:40:30.4417616Z   PAYLOAD: {"key": "value"}
2023-09-14T18:40:30.4417906Z   pythonLocation: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:30.4418447Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.8.18/x64/lib/pkgconfig
2023-09-14T18:40:30.4418798Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:30.4419179Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:30.4419495Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:30.4419828Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.8.18/x64/lib
2023-09-14T18:40:30.4420318Z ##[endgroup]
2023-09-14T18:40:30.8000284Z ##[group]Run scitt-emulator client create-claim --issuer did:web:example.org --content-type application/json --payload "${PAYLOAD}" --out claim.cose
2023-09-14T18:40:30.8001187Z [36;1mscitt-emulator client create-claim --issuer did:web:example.org --content-type application/json --payload "${PAYLOAD}" --out claim.cose[0m
2023-09-14T18:40:30.8068553Z shell: /usr/bin/bash -e {0}
2023-09-14T18:40:30.8068804Z env:
2023-09-14T18:40:30.8069066Z   SCITT_URL: http://localhost:8080
2023-09-14T18:40:30.8069340Z   PAYLOAD: {"key": "value"}
2023-09-14T18:40:30.8069638Z   pythonLocation: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:30.8070008Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.8.18/x64/lib/pkgconfig
2023-09-14T18:40:30.8070526Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:30.8070854Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:30.8071163Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:30.8071570Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.8.18/x64/lib
2023-09-14T18:40:30.8071852Z ##[endgroup]
2023-09-14T18:40:31.6148691Z Claim written to claim.cose
2023-09-14T18:40:31.6926358Z ##[group]Run # Create the middleware config file
2023-09-14T18:40:31.6926886Z [36;1m# Create the middleware config file[0m
2023-09-14T18:40:31.6927287Z [36;1mtee oidc-middleware-config.json <<EOF[0m
2023-09-14T18:40:31.6927585Z [36;1m{[0m
2023-09-14T18:40:31.6928107Z [36;1m    "issuers": ["https://token.actions.githubusercontent.com"],[0m
2023-09-14T18:40:31.6928633Z [36;1m    "claim_schema": {[0m
2023-09-14T18:40:31.6928978Z [36;1m        "https://token.actions.githubusercontent.com": {[0m
2023-09-14T18:40:31.6929381Z [36;1m              "\$schema": "https://json-schema.org/draft/2020-12/schema",[0m
2023-09-14T18:40:31.6929710Z [36;1m              "required": [[0m
2023-09-14T18:40:31.6929979Z [36;1m                  "job_workflow_ref",[0m
2023-09-14T18:40:31.6930277Z [36;1m                  "job_workflow_sha",[0m
2023-09-14T18:40:31.6930540Z [36;1m                  "repository_owner_id",[0m
2023-09-14T18:40:31.6930879Z [36;1m                  "repository_id"[0m
2023-09-14T18:40:31.6931130Z [36;1m              ],[0m
2023-09-14T18:40:31.6931365Z [36;1m              "properties": {[0m
2023-09-14T18:40:31.6931666Z [36;1m                  "job_workflow_ref": {[0m
2023-09-14T18:40:31.6931947Z [36;1m                      "type": "string",[0m
2023-09-14T18:40:31.6932214Z [36;1m                      "enum": [[0m
2023-09-14T18:40:31.6932467Z [36;1m                          "${WORKFLOW_REF}"[0m
2023-09-14T18:40:31.6932758Z [36;1m                      ][0m
2023-09-14T18:40:31.6932983Z [36;1m                  },[0m
2023-09-14T18:40:31.6933239Z [36;1m                  "job_workflow_sha": {[0m
2023-09-14T18:40:31.6933496Z [36;1m                      "type": "string",[0m
2023-09-14T18:40:31.6933753Z [36;1m                      "enum": [[0m
2023-09-14T18:40:31.6934155Z [36;1m                          "${JOB_WORKFLOW_SHA}"[0m
2023-09-14T18:40:31.6934414Z [36;1m                      ][0m
2023-09-14T18:40:31.6934653Z [36;1m                  },[0m
2023-09-14T18:40:31.6934922Z [36;1m                  "repository_owner_id": {[0m
2023-09-14T18:40:31.6935208Z [36;1m                      "type": "string",[0m
2023-09-14T18:40:31.6935471Z [36;1m                      "enum": [[0m
2023-09-14T18:40:31.6935735Z [36;1m                          "${REPOSITORY_OWNER_ID}"[0m
2023-09-14T18:40:31.6936005Z [36;1m                      ][0m
2023-09-14T18:40:31.6936237Z [36;1m                  },[0m
2023-09-14T18:40:31.6936496Z [36;1m                  "repository_id": {[0m
2023-09-14T18:40:31.6936771Z [36;1m                      "type": "string",[0m
2023-09-14T18:40:31.6937017Z [36;1m                      "enum": [[0m
2023-09-14T18:40:31.6937287Z [36;1m                          "${REPOSITORY_ID}"[0m
2023-09-14T18:40:31.6937784Z [36;1m                      ][0m
2023-09-14T18:40:31.6938011Z [36;1m                  }[0m
2023-09-14T18:40:31.6938220Z [36;1m              }[0m
2023-09-14T18:40:31.6938594Z [36;1m          }[0m
2023-09-14T18:40:31.6938812Z [36;1m    },[0m
2023-09-14T18:40:31.6939043Z [36;1m    "audience": "${SCITT_URL}"[0m
2023-09-14T18:40:31.6939259Z [36;1m}[0m
2023-09-14T18:40:31.6939458Z [36;1mEOF[0m
2023-09-14T18:40:31.6939763Z [36;1m# Start SCITT using the `OIDCAuthMiddleware` and associated config.[0m
2023-09-14T18:40:31.6940156Z [36;1mif [[ "x${SCITT_URL}" = "xhttp://localhost:8080" ]]; then[0m
2023-09-14T18:40:31.6940530Z [36;1m  scitt-emulator server --port 8080 --workspace workspace/ --tree-alg CCF \[0m
2023-09-14T18:40:31.6940921Z [36;1m    --middleware scitt_emulator.oidc:OIDCAuthMiddleware \[0m
2023-09-14T18:40:31.6941307Z [36;1m    --middleware-config-path oidc-middleware-config.json &[0m
2023-09-14T18:40:31.6941618Z [36;1m  sleep 1s[0m
2023-09-14T18:40:31.6941816Z [36;1mfi[0m
2023-09-14T18:40:31.6942080Z [36;1m# Submit the claim using OIDC token as auth[0m
2023-09-14T18:40:31.6942743Z [36;1mscitt-emulator client submit-claim --token "${OIDC_TOKEN}" --url "${SCITT_URL}" --claim claim.cose --out claim.receipt.cbor[0m
2023-09-14T18:40:31.7011644Z shell: /usr/bin/bash -e {0}
2023-09-14T18:40:31.7011883Z env:
2023-09-14T18:40:31.7012235Z   SCITT_URL: http://localhost:8080
2023-09-14T18:40:31.7012518Z   PAYLOAD: {"key": "value"}
2023-09-14T18:40:31.7013031Z   pythonLocation: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:31.7013409Z   PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.8.18/x64/lib/pkgconfig
2023-09-14T18:40:31.7013940Z   Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:31.7014287Z   Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:31.7014632Z   Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
2023-09-14T18:40:31.7014965Z   LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.8.18/x64/lib
2023-09-14T18:40:31.7076044Z   OIDC_TOKEN: ***
2023-09-14T18:40:31.7076638Z   WORKFLOW_REF: pdxjohnny/scitt-api-emulator/.github/workflows/notarize.yml@refs/heads/auth
2023-09-14T18:40:31.7077064Z   JOB_WORKFLOW_SHA: 215777b7ea418f1e0bd54f39cc70467e1fb76b8e
2023-09-14T18:40:31.7077376Z   REPOSITORY_OWNER_ID: 5950433
2023-09-14T18:40:31.7077603Z   REPOSITORY_ID: 621131680
2023-09-14T18:40:31.7077826Z ##[endgroup]
2023-09-14T18:40:31.7200561Z {
2023-09-14T18:40:31.7201150Z     "issuers": ["https://token.actions.githubusercontent.com"],
2023-09-14T18:40:31.7201602Z     "claim_schema": {
2023-09-14T18:40:31.7202649Z         "https://token.actions.githubusercontent.com": {
2023-09-14T18:40:31.7203667Z               "$schema": "https://json-schema.org/draft/2020-12/schema",
2023-09-14T18:40:31.7204084Z               "required": [
2023-09-14T18:40:31.7204953Z                   "job_workflow_ref",
2023-09-14T18:40:31.7205317Z                   "job_workflow_sha",
2023-09-14T18:40:31.7205676Z                   "repository_owner_id",
2023-09-14T18:40:31.7206054Z                   "repository_id"
2023-09-14T18:40:31.7206518Z               ],
2023-09-14T18:40:31.7206768Z               "properties": {
2023-09-14T18:40:31.7207313Z                   "job_workflow_ref": {
2023-09-14T18:40:31.7207777Z                       "type": "string",
2023-09-14T18:40:31.7208183Z                       "enum": [
2023-09-14T18:40:31.7208792Z                           "pdxjohnny/scitt-api-emulator/.github/workflows/notarize.yml@refs/heads/auth"
2023-09-14T18:40:31.7209459Z                       ]
2023-09-14T18:40:31.7209851Z                   },
2023-09-14T18:40:31.7210252Z                   "job_workflow_sha": {
2023-09-14T18:40:31.7210677Z                       "type": "string",
2023-09-14T18:40:31.7211030Z                       "enum": [
2023-09-14T18:40:31.7211610Z                           "215777b7ea418f1e0bd54f39cc70467e1fb76b8e"
2023-09-14T18:40:31.7212060Z                       ]
2023-09-14T18:40:31.7212537Z                   },
2023-09-14T18:40:31.7213290Z                   "repository_owner_id": {
2023-09-14T18:40:31.7213797Z                       "type": "string",
2023-09-14T18:40:31.7214239Z                       "enum": [
2023-09-14T18:40:31.7214665Z                           "5950433"
2023-09-14T18:40:31.7215145Z                       ]
2023-09-14T18:40:31.7215649Z                   },
2023-09-14T18:40:31.7216015Z                   "repository_id": {
2023-09-14T18:40:31.7216456Z                       "type": "string",
2023-09-14T18:40:31.7217166Z                       "enum": [
2023-09-14T18:40:31.7218186Z                           "621131680"
2023-09-14T18:40:31.7219409Z                       ]
2023-09-14T18:40:31.7219893Z                   }
2023-09-14T18:40:31.7220618Z               }
2023-09-14T18:40:31.7221061Z           }
2023-09-14T18:40:31.7221629Z     },
2023-09-14T18:40:31.7222511Z     "audience": "http://localhost:8080"
2023-09-14T18:40:31.7223154Z }
2023-09-14T18:40:32.6199980Z Service private key written to workspace/storage/service_private_key.pem
2023-09-14T18:40:32.6201041Z Service parameters written to workspace/service_parameters.json
2023-09-14T18:40:32.6202252Z Service parameters: workspace/service_parameters.json
2023-09-14T18:40:32.6203356Z  * Serving Flask app 'scitt_emulator.server'
2023-09-14T18:40:32.6203718Z  * Debug mode: on
2023-09-14T18:40:32.7094396Z [31m[1mWARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.[0m
2023-09-14T18:40:32.7095450Z  * Running on all addresses (0.0.0.0)
2023-09-14T18:40:32.7145016Z  * Running on http://127.0.0.1:8080
2023-09-14T18:40:32.7145373Z  * Running on http://10.1.0.31:8080
2023-09-14T18:40:32.7146061Z [33mPress CTRL+C to quit[0m
2023-09-14T18:40:32.7146447Z  * Restarting with stat
2023-09-14T18:40:33.5432606Z  * Debugger is active!
2023-09-14T18:40:33.6551588Z  * Debugger PIN: 196-443-470
2023-09-14T18:40:33.8392683Z 127.0.0.1 - - [14/Sep/2023 18:40:33] "[35m[1mPOST /entries HTTP/1.1[0m" 201 -
2023-09-14T18:40:33.8484629Z 127.0.0.1 - - [14/Sep/2023 18:40:33] "GET /entries/1/receipt HTTP/1.1" 200 -
2023-09-14T18:40:33.8499398Z Claim registered with entry ID 1
2023-09-14T18:40:33.8500039Z Receipt written to claim.receipt.cbor
2023-09-14T18:40:38.9105979Z Post job cleanup.
2023-09-14T18:40:39.1293021Z Post job cleanup.
2023-09-14T18:40:39.8543985Z [command]/usr/bin/git version
2023-09-14T18:40:39.8554370Z git version 2.42.0
2023-09-14T18:40:39.8560299Z Temporarily overriding HOME='/home/runner/work/_temp/7644865c-1244-4363-9de6-a8fd9a0b3c45' before making global git config changes
2023-09-14T18:40:39.8560996Z Adding repository directory to the temporary git global config as a safe directory
2023-09-14T18:40:39.8561768Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/scitt-api-emulator/scitt-api-emulator
2023-09-14T18:40:39.8562846Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
2023-09-14T18:40:39.8564506Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
2023-09-14T18:40:39.8565690Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2023-09-14T18:40:39.8566385Z http.https://github.com/.extraheader
2023-09-14T18:40:39.8567437Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
2023-09-14T18:40:39.8568986Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
2023-09-14T18:40:39.8779993Z Cleaning up orphan processes
2023-09-14T18:40:39.9436849Z Terminate orphan process: pid (1825) (scitt-emulator)
2023-09-14T18:40:39.9710884Z Terminate orphan process: pid (1829) (python)
```

</details>